### PR TITLE
style: Changed hint text for passcode

### DIFF
--- a/mifospay/src/main/res/layout/activity_edit_profile.xml
+++ b/mifospay/src/main/res/layout/activity_edit_profile.xml
@@ -201,7 +201,7 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:hint="Current Passcode"
-                                android:inputType="textPassword"/>
+                                android:inputType="numberPassword"/>
 
                         </android.support.design.widget.TextInputLayout>
 
@@ -218,7 +218,7 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:hint="New Passcode"
-                                android:inputType="textPassword"/>
+                                android:inputType="numberPassword"/>
                         </android.support.design.widget.TextInputLayout>
 
                         <android.support.design.widget.TextInputLayout
@@ -234,7 +234,7 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:hint="Confirm New Passcode"
-                                android:inputType="textPassword"/>
+                                android:inputType="numberPassword"/>
                         </android.support.design.widget.TextInputLayout>
 
                         <LinearLayout

--- a/mifospay/src/main/res/layout/activity_edit_profile.xml
+++ b/mifospay/src/main/res/layout/activity_edit_profile.xml
@@ -217,7 +217,7 @@
                                 android:id="@+id/et_new_passcode"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:hint="New Password"
+                                android:hint="New Passcode"
                                 android:inputType="textPassword"/>
                         </android.support.design.widget.TextInputLayout>
 


### PR DESCRIPTION
Fixes #61 

Screenshot:
![ezgif com-resize](https://user-images.githubusercontent.com/36307309/47566351-18feec80-d949-11e8-9887-852c96bf5f65.png)



Hint text for ```Change Passcdode``` is modified.

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


