### PR TITLE
fix #61 :Changed hint text for 'New Passcode' text field

### DIFF
--- a/mifospay/src/main/res/layout/activity_edit_profile.xml
+++ b/mifospay/src/main/res/layout/activity_edit_profile.xml
@@ -217,7 +217,7 @@
                                 android:id="@+id/et_new_passcode"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:hint="New Password"
+                                android:hint="New Passcode"
                                 android:inputType="textPassword"/>
                         </android.support.design.widget.TextInputLayout>
 


### PR DESCRIPTION
Fixes #61 

**Screenshot:**
![ezgif com-resize](https://user-images.githubusercontent.com/36307309/47649023-e3087500-dba1-11e8-955e-a3d654828c9e.png)

Changed the hint text for the ```New Passcode``` text field in Profile Activity.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


