### PR TITLE
Fix: #76 User can save correct number now

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
@@ -11,7 +11,6 @@ import android.os.Bundle;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.design.widget.BottomSheetDialog;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.CardView;
 import android.util.Log;
@@ -21,7 +20,6 @@ import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.hbb20.CountryCodePicker;
 
@@ -40,7 +38,6 @@ import javax.inject.Inject;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import butterknife.Optional;
 
 public class EditProfileActivity extends BaseActivity implements
         EditProfileContract.EditProfileView {
@@ -135,11 +132,11 @@ public class EditProfileActivity extends BaseActivity implements
         showBackButton();
         setToolbarTitle(Constants.EDIT_PROFILE);
         mPresenter.attachView(this);
+        mCcpNewCode.registerCarrierNumberEditText(mEtNewMobileNumber);
 
         showProgressDialog(Constants.PLEASE_WAIT);
         mEditProfilePresenter.fetchUserDetails();
 
-        mCcpNewCode.registerCarrierNumberEditText(mEtNewMobileNumber);
         setupBottomSheetDialog();
     }
 
@@ -232,10 +229,15 @@ public class EditProfileActivity extends BaseActivity implements
             }
             AnimationUtil.expand(mLlMobile);
             mTvCurrentMobileNumber.setVisibility(View.GONE);
-            mEtNewMobileNumber.setText(mobile);
+            String mobileNumberWithCountryCodeExcluded = excludeCountryCodeFromString(mobile);
+            mEtNewMobileNumber.setText(mobileNumberWithCountryCodeExcluded);
         }
     }
 
+    private String excludeCountryCodeFromString(String str) {
+        String selectedCountryCode = mCcpNewCode.getSelectedCountryCode();
+        return str.substring(selectedCountryCode.length(), str.length());
+    }
 
     @OnClick({R.id.btn_password_cancel, R.id.btn_password_save, R.id.btn_passcode_cancel,
             R.id.btn_pasccode_save, R.id.btn_email_cancel, R.id.btn_email_save,
@@ -302,6 +304,7 @@ public class EditProfileActivity extends BaseActivity implements
 
             case R.id.btn_mobile_save:
                 showProgressDialog(Constants.PLEASE_WAIT);
+
                 if (mCcpNewCode.isValidFullNumber()) {
                     mEditProfilePresenter.updateMobile(mCcpNewCode.getFullNumber());
                 } else {

--- a/mifospay/src/main/res/layout/activity_edit_profile.xml
+++ b/mifospay/src/main/res/layout/activity_edit_profile.xml
@@ -406,6 +406,7 @@
                                 android:layout_height="wrap_content"
                                 android:layout_marginLeft="@dimen/value_5dp"
                                 android:hint="Mobile Number"
+                                android:maxLength="@integer/telephone_numbers_max_length_standard"
                                 android:inputType="number"/>
 
                         </LinearLayout>

--- a/mifospay/src/main/res/values/integers.xml
+++ b/mifospay/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="telephone_numbers_max_length_standard">15</integer>
+</resources>


### PR DESCRIPTION
Fixes #76 

Please Add Screenshots If any UI changes.

![ezgif-4-07b2895af235](https://user-images.githubusercontent.com/18665370/48301806-ed0c6b00-e4f3-11e8-80d5-e96fe4824e32.gif)

Please Add Summary of what changes you have made. (Optional)

The bug occurred because of country code which was added to the input. For now, only for input case, we format mobile number by excluding country code, so always if the number is correct it will be saved.

I've also added the length limit to the input which equals 15 characters (International standard).

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


