### PR TITLE
Fix #89: Edit Profile Photo Header Should Not Be Persistent

### DIFF
--- a/mifospay/src/main/res/layout/activity_edit_profile.xml
+++ b/mifospay/src/main/res/layout/activity_edit_profile.xml
@@ -14,15 +14,6 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <de.hdodenhof.circleimageview.CircleImageView
-        android:id="@+id/iv_user_image"
-        android:layout_width="@dimen/user_profile_image_size"
-        android:layout_height="@dimen/user_profile_image_size"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginLeft="10dp"
-        android:layout_marginTop="30dp"
-        android:layout_marginRight="10dp" />
-
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -32,6 +23,16 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:padding="@dimen/value_20dp">
+
+            <de.hdodenhof.circleimageview.CircleImageView
+                android:id="@+id/iv_user_image"
+                android:layout_width="@dimen/user_profile_image_size"
+                android:layout_height="@dimen/user_profile_image_size"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginLeft="10dp"
+                android:layout_marginTop="30dp"
+                android:layout_marginRight="10dp"
+                android:layout_marginBottom="20dp"/>
 
             <android.support.v7.widget.CardView
                 android:id="@+id/cv_password"


### PR DESCRIPTION
Fixes #89

Please Add Screenshots If any UI changes.
![image](https://user-images.githubusercontent.com/24931732/48316901-75dfe100-e59e-11e8-9eca-cb4b501fc140.png)

The profile picture is now able to be scrolled away, leaving room for other content.


