### PR TITLE
Feat: Redesign Payments Tab

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/adapter/PaymentsAdapter.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/adapter/PaymentsAdapter.java
@@ -1,0 +1,42 @@
+package org.mifos.mobilewallet.mifospay.home.adapter;
+
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
+
+import org.mifos.mobilewallet.mifospay.payments.ui.HistoryFragment;
+import org.mifos.mobilewallet.mifospay.payments.ui.InvoicesFragment;
+import org.mifos.mobilewallet.mifospay.payments.ui.RequestFragment;
+import org.mifos.mobilewallet.mifospay.payments.ui.SendFragment;
+
+public class PaymentsAdapter extends FragmentStatePagerAdapter {
+    private final Fragment[] mFragments = {
+            new SendFragment(),
+            new RequestFragment(),
+            new HistoryFragment(),
+            new InvoicesFragment()
+    };
+    private final String[] mTitles;
+
+    public PaymentsAdapter(FragmentManager fm, String[] titles) {
+        super(fm);
+        mTitles = titles;
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+        return mFragments[position];
+    }
+
+    @Override
+    public int getCount() {
+        return mFragments.length;
+    }
+
+    @Nullable
+    @Override
+    public CharSequence getPageTitle(int position) {
+        return mTitles[position];
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/MainActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/MainActivity.java
@@ -120,12 +120,14 @@ public class MainActivity extends BaseActivity implements BaseHomeContract.BaseH
                     break;
 
                 case R.id.action_payments:
-                    replaceFragment(new TransferFragment(), false,
+                    replaceFragment(new PaymentsFragment(), false,
                             R.id.bottom_navigation_fragment_container);
                     break;
 
                 case R.id.action_finance:
                     // TODO: REDESIGN - CREATE FINANCE FRAGMENT
+                    replaceFragment(new TransferFragment(), false,
+                            R.id.bottom_navigation_fragment_container);
                     break;
 
                 case R.id.action_profile:

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/PaymentsFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/PaymentsFragment.java
@@ -1,0 +1,39 @@
+package org.mifos.mobilewallet.mifospay.home.ui;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.mifos.mobilewallet.mifospay.R;
+import org.mifos.mobilewallet.mifospay.base.BaseFragment;
+import org.mifos.mobilewallet.mifospay.home.adapter.PaymentsAdapter;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+public class PaymentsFragment extends BaseFragment {
+
+    @BindView(R.id.vp_payments)
+    ViewPager mViewPager;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        setToolbarTitle(getString(R.string.payments));
+        View root = inflater.inflate(R.layout.fragment_payments, container, false);
+        ButterKnife.bind(this, root);
+        String[] titles = {
+                getString(R.string.send),
+                getString(R.string.request),
+                getString(R.string.history),
+                getString(R.string.invoices)
+        };
+        mViewPager.setAdapter(new PaymentsAdapter(getChildFragmentManager(), titles));
+        return root;
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/HistoryFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/HistoryFragment.java
@@ -1,0 +1,24 @@
+package org.mifos.mobilewallet.mifospay.payments.ui;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.mifos.mobilewallet.mifospay.R;
+import org.mifos.mobilewallet.mifospay.base.BaseFragment;
+
+import butterknife.ButterKnife;
+
+public class HistoryFragment extends BaseFragment {
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_history, container, false);
+        ButterKnife.bind(this, root);
+        return root;
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/InvoicesFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/InvoicesFragment.java
@@ -1,0 +1,24 @@
+package org.mifos.mobilewallet.mifospay.payments.ui;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.mifos.mobilewallet.mifospay.R;
+import org.mifos.mobilewallet.mifospay.base.BaseFragment;
+
+import butterknife.ButterKnife;
+
+public class InvoicesFragment extends BaseFragment {
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_invoices, container, false);
+        ButterKnife.bind(this, root);
+        return root;
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/RequestFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/RequestFragment.java
@@ -1,0 +1,24 @@
+package org.mifos.mobilewallet.mifospay.payments.ui;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.mifos.mobilewallet.mifospay.R;
+import org.mifos.mobilewallet.mifospay.base.BaseFragment;
+
+import butterknife.ButterKnife;
+
+public class RequestFragment extends BaseFragment {
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_request, container, false);
+        ButterKnife.bind(this, root);
+        return root;
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
@@ -1,0 +1,24 @@
+package org.mifos.mobilewallet.mifospay.payments.ui;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.mifos.mobilewallet.mifospay.R;
+import org.mifos.mobilewallet.mifospay.base.BaseFragment;
+
+import butterknife.ButterKnife;
+
+public class SendFragment extends BaseFragment {
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_send, container, false);
+        ButterKnife.bind(this, root);
+        return root;
+    }
+}

--- a/mifospay/src/main/res/drawable/ic_history_white_24dp.xml
+++ b/mifospay/src/main/res/drawable/ic_history_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L6,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z" />
+</vector>

--- a/mifospay/src/main/res/drawable/ic_outline_description_24dp.xml
+++ b/mifospay/src/main/res/drawable/ic_outline_description_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8,16h8v2L8,18zM8,12h8v2L8,14zM14,2L6,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM18,20L6,20L6,4h7v5h5v11z" />
+</vector>

--- a/mifospay/src/main/res/layout/fragment_history.xml
+++ b/mifospay/src/main/res/layout/fragment_history.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/iv_empty_history"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        android:contentDescription="@string/empty_no_transaction_history_title"
+        android:tint="@color/colorBlack38"
+        app:layout_constraintBottom_toTopOf="@id/tv_empty_history"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:srcCompat="@drawable/ic_history_white_24dp" />
+
+    <TextView
+        android:id="@+id/tv_empty_history"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/value_12dp"
+        android:text="@string/empty_no_transaction_history_title"
+        android:textColor="@color/colorBlack50"
+        android:textSize="@dimen/value_16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/iv_empty_history" />
+</android.support.constraint.ConstraintLayout>

--- a/mifospay/src/main/res/layout/fragment_invoices.xml
+++ b/mifospay/src/main/res/layout/fragment_invoices.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/iv_empty_invoice"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        android:contentDescription="@string/nothing_in_invoices"
+        android:tint="@color/colorBlack38"
+        app:layout_constraintBottom_toTopOf="@id/tv_empty_invoice"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:srcCompat="@drawable/ic_outline_description_24dp" />
+
+    <TextView
+        android:id="@+id/tv_empty_invoice"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/value_12dp"
+        android:text="@string/nothing_in_invoices"
+        android:textColor="@color/colorBlack50"
+        android:textSize="@dimen/value_16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/iv_empty_invoice" />
+</android.support.constraint.ConstraintLayout>

--- a/mifospay/src/main/res/layout/fragment_payments.xml
+++ b/mifospay/src/main/res/layout/fragment_payments.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.view.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/vp_payments"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.design.widget.TabLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:tabMode="scrollable" />
+</android.support.v4.view.ViewPager>

--- a/mifospay/src/main/res/layout/fragment_request.xml
+++ b/mifospay/src/main/res/layout/fragment_request.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/value_16sp"
+        android:text="@string/select_transfer_method"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>

--- a/mifospay/src/main/res/layout/fragment_send.xml
+++ b/mifospay/src/main/res/layout/fragment_send.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/value_16sp"
+        android:text="@string/select_transfer_method"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="transaction_history">Transaction History</string>
     <string name="invoices">Invoices</string>
     <string name="request">Request</string>
+    <string name="history">History</string>
     <string name="bank_account">Bank Account</string>
     <string name="qr_code">QR code</string>
     <string name="complete_kyc">Complete KYC</string>
@@ -130,6 +131,8 @@
 
     <string name="fetching">Fetching…</string>
     <string name="empty_no_transaction_history_title">Your history is empty</string>
+    <string name="nothing_in_invoices">Nothing in Invoices</string>
+    <string name="select_transfer_method">Select transfer method</string>
     <string name="empty_no_transaction_history_subtitle">Complete a transfer and come back here to see results!</string>
     <string name="error_oops">Oops!</string>
     <string name="error_no_transaction_history_subtitle">Couldn\'t fetch transactions history. Please, try again.</string>


### PR DESCRIPTION
Fixes #122 

![20181209_140739](https://user-images.githubusercontent.com/28915865/49695131-2223e000-fbbc-11e8-895f-2616b1f8c515.gif)


- Redesign Payments Tab and transfer fragment has been moved to the Finance tab
- I have used a dummy TextView in the ViewPager

Checks:

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them