### PR TITLE
Removed unused namespace declaration in XML files

### DIFF
--- a/mifospay/src/main/res/layout/activity_faq.xml
+++ b/mifospay/src/main/res/layout/activity_faq.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent" android:layout_height="match_parent"
     tools:context=".faq.ui.FAQActivity">

--- a/mifospay/src/main/res/menu/menu_profile.xml
+++ b/mifospay/src/main/res/menu/menu_profile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
       xmlns:tools="http://schemas.android.com/tools"
       tools:context=".home.ui.HomeActivity">
 


### PR DESCRIPTION
**Summary**
Fixes #235 
Removed unused namespace declaration in XML files.
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


