### PR TITLE
Fixed Groovy warnings

### DIFF
--- a/config/quality/quality.gradle
+++ b/config/quality/quality.gradle
@@ -18,7 +18,7 @@ dependencies {
     checkstyle 'com.puppycrawl.tools:checkstyle:6.5'
 }
 
-def qualityConfigDir = "$project.rootDir/config/quality";
+def qualityConfigDir = "$project.rootDir/config/quality"
 def reportsDir = "$project.buildDir/reports"
 
 check.dependsOn 'checkstyle', 'findbugs', 'pmd'
@@ -31,6 +31,7 @@ task checkstyle(type: Checkstyle, group: 'Verification', description: 'Runs code
     reports {
         xml.enabled = true
         xml {
+            //noinspection GrDeprecatedAPIUsage
             destination "$reportsDir/checkstyle/checkstyle.xml"
         }
     }
@@ -58,9 +59,11 @@ task findbugs(type: FindBugs,
         xml.enabled = false
         html.enabled = true
         xml {
+            //noinspection GrDeprecatedAPIUsage
             destination "$reportsDir/findbugs/findbugs.xml"
         }
         html {
+            //noinspection GrDeprecatedAPIUsage
             destination "$reportsDir/findbugs/findbugs.html"
         }
     }
@@ -82,9 +85,11 @@ task pmd(type: Pmd, group: 'Verification', description: 'Inspect sourcecode for 
         xml.enabled = true
         html.enabled = true
         xml {
+            //noinspection GrDeprecatedAPIUsage
             destination "$reportsDir/pmd/pmd.xml"
         }
         html {
+            //noinspection GrDeprecatedAPIUsage
             destination "$reportsDir/pmd/pmd.html"
         }
     }


### PR DESCRIPTION
**Summary**
Fixes some part of the #236 
Fixed Groovy warnings ( 6 warnings )
Removed unnecessary semi-column in `quality.gradle` file
Suppressed the warnings in `quality.gradle` file due to deprecated method `destination`

**Screenshots**
**Before fixing:**
![screenshot from 2019-01-29 17-40-20](https://user-images.githubusercontent.com/30550059/51908436-de956780-23ef-11e9-92ca-306f2ac307b4.png)

**After fixing:**
![screenshot from 2019-01-29 17-43-55](https://user-images.githubusercontent.com/30550059/51908450-e3f2b200-23ef-11e9-85b6-445aabf41073.png)


**Changes**
Fixed Groovy warnings

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.