### PR TITLE
fix : Removed Android Accessibility Lint Warnings

### DIFF
--- a/mifospay/src/main/res/layout/activity_signup.xml
+++ b/mifospay/src/main/res/layout/activity_signup.xml
@@ -187,7 +187,7 @@
                     android:background="@drawable/bg_et_round_border"
                     android:clickable="true"
                     android:cursorVisible="false"
-                    android:focusable="false"
+                    android:focusable="true"
                     android:focusableInTouchMode="false"
                     android:hint="@string/state"
                     android:inputType="text"

--- a/mifospay/src/main/res/layout/dialog_choose_signup_method.xml
+++ b/mifospay/src/main/res/layout/dialog_choose_signup_method.xml
@@ -37,7 +37,8 @@
                 android:drawablePadding="@dimen/value_15dp"
                 android:text="@string/merchant"
                 android:textAllCaps="false"
-                android:textColor="@color/primaryBlue"/>
+                android:textColor="@color/primaryBlue"
+                android:focusable="true" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -58,7 +59,8 @@
                 android:drawablePadding="@dimen/value_15dp"
                 android:text="@string/customer"
                 android:textAllCaps="false"
-                android:textColor="@color/primaryBlue"/>
+                android:textColor="@color/primaryBlue"
+                android:focusable="true" />
 
         </LinearLayout>
 

--- a/mifospay/src/main/res/layout/dialog_choose_sim_dialog.xml
+++ b/mifospay/src/main/res/layout/dialog_choose_sim_dialog.xml
@@ -104,7 +104,8 @@
                 android:text="@string/confirm"
                 android:textAllCaps="false"
                 android:textColor="@android:color/white"
-                android:typeface="sans"/>
+                android:typeface="sans"
+                android:focusable="true" />
 
         </LinearLayout>
     </ScrollView>

--- a/mifospay/src/main/res/layout/fragment_cards.xml
+++ b/mifospay/src/main/res/layout/fragment_cards.xml
@@ -46,6 +46,7 @@
         android:text="@string/add_card"
         android:textAllCaps="false"
         android:textColor="@color/primaryBlue"
-        android:typeface="sans"/>
+        android:typeface="sans"
+        android:focusable="true" />
 
 </FrameLayout>

--- a/mifospay/src/main/res/layout/fragment_kyc_lvl1.xml
+++ b/mifospay/src/main/res/layout/fragment_kyc_lvl1.xml
@@ -84,7 +84,7 @@
             android:layout_height="wrap_content"
             android:clickable="true"
             android:cursorVisible="false"
-            android:focusable="false"
+            android:focusable="true"
             android:focusableInTouchMode="false"
             android:hint="@string/date_of_birth"
             android:theme="@style/Theme.AppCompat.Light"/>

--- a/mifospay/src/main/res/layout/fragment_transfer.xml
+++ b/mifospay/src/main/res/layout/fragment_transfer.xml
@@ -43,7 +43,8 @@
                 android:text="@string/vpa"
                 android:textAllCaps="false"
                 android:textColor="@android:color/white"
-                android:typeface="sans"/>
+                android:typeface="sans"
+                android:focusable="true" />
 
             <Button
                 android:id="@+id/btn_mobile"
@@ -55,7 +56,8 @@
                 android:text="@string/mobile_number"
                 android:textAllCaps="false"
                 android:textColor="@android:color/black"
-                android:typeface="sans"/>
+                android:typeface="sans"
+                android:focusable="true" />
 
         </LinearLayout>
 


### PR DESCRIPTION
Fixes some part of the issue #236 

**Summary** 
Removed Android Keyboard inaccessible widget lint warnings by adding focusable to true.
A widget that is declared to be clickable but not declared to be focusable is not accessible via the keyboard. we should add the focusable attribute as well.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


