### PR TITLE
fix : The fourth digit of expiry year is now visible to user

### DIFF
--- a/mifospay/src/main/res/layout/fragment_debit_card.xml
+++ b/mifospay/src/main/res/layout/fragment_debit_card.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="@dimen/value_20dp">
+    android:padding="@dimen/value_12dp">
 
     <EditText
         android:id="@+id/et_debit_card_number"


### PR DESCRIPTION
Fixes #382 

Please Add Screenshots If any UI changes.

**Before Changes**
![screenshot_2019-03-01-16-46-19-561_org mifos mobilewallet mifospay](https://user-images.githubusercontent.com/30550059/53637355-f22f2a80-3c48-11e9-9dc4-48cb7821a1c6.png)

**After Changes**
![screenshot_2019-03-01-16-48-57-741_org mifos mobilewallet mifospay](https://user-images.githubusercontent.com/30550059/53637387-04a96400-3c49-11e9-8598-b0bdadd865fe.png)


**Summary** 
Decreased the padding of the linear layout from 20dp to 12 dp in `fragment_debit_card.xml`.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


