### PR TITLE
feat : Added Offline Profile Pic Storage and Pic view

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/ProfileFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/ProfileFragment.java
@@ -1,6 +1,8 @@
 package org.mifos.mobilewallet.mifospay.home.ui;
 
+import android.app.AlertDialog;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
@@ -12,16 +14,19 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import android.widget.Toast;
 import org.mifos.mobilewallet.core.domain.model.client.Client;
 import org.mifos.mobilewallet.mifospay.R;
 import org.mifos.mobilewallet.mifospay.base.BaseActivity;
 import org.mifos.mobilewallet.mifospay.base.BaseFragment;
+import org.mifos.mobilewallet.mifospay.data.local.PreferencesHelper;
 import org.mifos.mobilewallet.mifospay.editprofile.ui.EditProfileActivity;
 import org.mifos.mobilewallet.mifospay.faq.ui.FAQActivity;
 import org.mifos.mobilewallet.mifospay.home.HomeContract;
 import org.mifos.mobilewallet.mifospay.home.presenter.ProfilePresenter;
 import org.mifos.mobilewallet.mifospay.settings.ui.SettingsActivity;
 import org.mifos.mobilewallet.mifospay.utils.Constants;
+import org.mifos.mobilewallet.mifospay.utils.ImageInputOutput;
 import org.mifos.mobilewallet.mifospay.utils.TextDrawable;
 import org.mifos.mobilewallet.mifospay.utils.Toaster;
 
@@ -54,6 +59,9 @@ public class ProfileFragment extends BaseFragment implements HomeContract.Profil
     @BindView(R.id.tv_client_vpa)
     TextView tvClientVpa;
 
+    boolean isProfile = false;
+    private ImageInputOutput imageInputOutput;
+
     public static ProfileFragment newInstance(long clientId) {
 
         Bundle args = new Bundle();
@@ -69,6 +77,47 @@ public class ProfileFragment extends BaseFragment implements HomeContract.Profil
         ((BaseActivity) getActivity()).getActivityComponent().inject(this);
     }
 
+    @Override public void onResume() {
+        super.onResume();
+        PreferencesHelper preferencesHelper = new PreferencesHelper(getContext());
+        final Bitmap bitmap = imageInputOutput.load();
+        if (bitmap != null) {
+            isProfile = true;
+        } else {
+            isProfile = false;
+        }
+        ivUserImage.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View v) {
+                View dialogView = View.inflate(getContext(),
+                        R.layout.dialog_show_profile_picture, null);
+                AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+                ImageView profilepic = dialogView.findViewById(R.id.profile_pic);
+                builder.setView(dialogView);
+                builder.setCancelable(true);
+                AlertDialog dialog = builder.create();
+                dialog.getWindow().getAttributes().windowAnimations = R.style.DialogAnimation;
+
+                if (isProfile) {
+                    profilepic.setImageBitmap(bitmap);
+                    dialog.show();
+                } else {
+                    Toast.makeText(getContext(), "No Profile Pic", Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
+
+        if (bitmap != null) {
+            ivUserImage.setImageBitmap(bitmap);
+        } else {
+            String s = preferencesHelper.getFullName();
+            TextDrawable drawable = TextDrawable.builder().beginConfig()
+                    .width((int)getResources().getDimension(R.dimen.user_profile_image_size))
+                    .height((int)getResources().getDimension(R.dimen.user_profile_image_size))
+                    .endConfig().buildRound(s.substring(0, 1), R.color.colorPrimary);
+            ivUserImage.setImageDrawable(drawable);
+        }
+    }
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
@@ -80,12 +129,15 @@ public class ProfileFragment extends BaseFragment implements HomeContract.Profil
         setToolbarTitle(Constants.PROFILE);
         hideBackButton();
         setSwipeEnabled(false);
-
+        imageInputOutput = new ImageInputOutput(getContext(), "profile");
         setHasOptionsMenu(true);
 
         mProfilePresenter.fetchprofile();
         mProfilePresenter.fetchClientImage();
-
+        Bitmap bitmap = imageInputOutput.load();
+        if (bitmap != null) {
+            ivUserImage.setImageBitmap(bitmap);
+        }
         return rootView;
     }
 
@@ -144,5 +196,6 @@ public class ProfileFragment extends BaseFragment implements HomeContract.Profil
     public void showSnackbar(String message) {
         Toaster.show(getView(), message);
     }
+
 
 }

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/ImageInputOutput.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/ImageInputOutput.java
@@ -1,0 +1,70 @@
+package org.mifos.mobilewallet.mifospay.utils;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.support.annotation.NonNull;
+import android.util.Log;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class ImageInputOutput {
+
+    Context context;
+    String imageName;
+
+    public ImageInputOutput(Context context, String imageName) {
+        this.imageName = imageName;
+        this.context = context;
+    }
+
+    public void savebitmap(Bitmap bitmapImage) {
+        FileOutputStream fileOutputStream = null;
+        try {
+            fileOutputStream = new FileOutputStream(createFile());
+            bitmapImage.compress(Bitmap.CompressFormat.PNG, 100, fileOutputStream);
+        } catch (Exception e) {
+            Log.e("InputOutput", e.toString());
+        } finally {
+            try {
+                if (fileOutputStream != null) {
+                    fileOutputStream.close();
+                }
+            } catch (IOException e) {
+                Log.e("InputOutput", e.toString());
+            }
+        }
+    }
+
+
+    public Bitmap load() {
+        FileInputStream inputStream = null;
+        try {
+            inputStream = new FileInputStream(createFile());
+            return BitmapFactory.decodeStream(inputStream);
+        } catch (Exception e) {
+            Log.e("InputOutput", e.toString());
+        } finally {
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (IOException e) {
+                Log.e("InputOutput", e.toString());
+            }
+        }
+        return null;
+    }
+
+    @NonNull
+    private File createFile() {
+        File directory;
+        directory = new File(context.getFilesDir() + "/" + "mifos-wallet");
+        if (!directory.exists()) {
+            directory.mkdir();
+        }
+        return new File(directory, imageName + ".png");
+    }
+}

--- a/mifospay/src/main/res/layout/dialog_show_profile_picture.xml
+++ b/mifospay/src/main/res/layout/dialog_show_profile_picture.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:orientation="vertical"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center">
+
+    <ImageView
+        android:layout_width="350sp"
+        android:layout_height="350sp"
+        android:layout_gravity="center"
+        android:id="@+id/profile_pic"
+        />
+
+</LinearLayout>

--- a/mifospay/src/main/res/values/styles.xml
+++ b/mifospay/src/main/res/values/styles.xml
@@ -31,4 +31,8 @@
         <item name="colorControlHighlight">@color/colorAccent</item>
     </style>
 
+    <style name="DialogAnimation">
+        <item name="android:windowEnterAnimation">@android:anim/fade_in</item>
+        <item name="android:windowExitAnimation">@android:anim/fade_out</item>
+    </style>
 </resources>


### PR DESCRIPTION
Fixes #365 

Currently, if a user adds his profile pic it just gets added in one section and doesn't get saved ( in Server )
Implemented a function to save that extracted Bitmap locally and fetch it every time we need to use it 

also added the profile pic viewer as once the user has added his profile pic he can view it in an animated dialog box as shown in GIF


![20190305_195950](https://user-images.githubusercontent.com/32003964/53812367-591e4d80-3f81-11e9-871d-50201ef3aba5.gif)
