### PR TITLE
fix : Verify the credit card number using Luhn's Algorithm while adding Card

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/CardsContract.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/CardsContract.java
@@ -44,5 +44,7 @@ public interface CardsContract {
         void editCard(Card card);
 
         void deleteCard(int position);
+
+        boolean validateCreditCardNumber(String str);
     }
 }

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/presenter/CardsPresenter.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/presenter/CardsPresenter.java
@@ -192,12 +192,8 @@ public class CardsPresenter implements CardsContract.CardsPresenter {
      * Luhn Algorithm for validating Credit Card Number
      * src: https://www.journaldev.com/1443/java-credit-card-validation-luhn-algorithm-java
      */
-    private boolean validateCreditCardNumber(String str) {
-
-        int u = 2;
-        if (u - 2 == 0) {
-            return true; // for backend testing. remove after testing.
-        }
+    @Override
+    public boolean validateCreditCardNumber(String str) {
 
         if (str.length() == 0) {
             return false;

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/ui/AddCardDialog.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/ui/AddCardDialog.java
@@ -147,18 +147,22 @@ public class AddCardDialog extends BottomSheetDialogFragment {
         if (!areFieldsValid()) {
             return;
         }
-        Card card = new Card(etCardNumber.getText().toString(), etCVV.getText().toString(),
-                spnMM.getSelectedItem() + "/" + spnYY.getSelectedItem(),
-                etFname.getText().toString(), etLname.getText().toString());
+        if (mCardsPresenter.validateCreditCardNumber(etCardNumber.getText().toString())) {
+            Card card = new Card(etCardNumber.getText().toString(), etCVV.getText().toString(),
+                    spnMM.getSelectedItem() + "/" + spnYY.getSelectedItem(),
+                    etFname.getText().toString(), etLname.getText().toString());
 
-        if (forEdit) {
-            card.setId(editCard.getId());
-            mCardsPresenter.editCard(card);
+            if (forEdit) {
+                card.setId(editCard.getId());
+                mCardsPresenter.editCard(card);
+            } else {
+                mCardsPresenter.addCard(card);
+            }
+
+            dismiss();
         } else {
-            mCardsPresenter.addCard(card);
+            Toaster.showToast(getContext(), getString(R.string.enter_valid_card_number));
         }
-
-        dismiss();
     }
 
     /**

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -189,6 +189,7 @@
     <string name="faq">FAQ</string>
     <string name="settings">Settings</string>
     <string name="mobile_number">Mobile Number</string>
+    <string name="enter_valid_card_number">Please enter valid Credit/Debit Card Number</string>
 
 
 </resources>


### PR DESCRIPTION
Fixes #420 

**Summary**
Added validation checker and limited the digits length of Credit Card Number in Saved Cards.
![screenshot_2019-03-06-18-17-12-189_org mifos mobilewallet mifospay](https://user-images.githubusercontent.com/30550059/53883322-a7dded00-403e-11e9-926f-c3f11e4414a9.png)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


