### PR TITLE
fix : App crash while Registering

### DIFF
--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -160,7 +160,6 @@
         android:layout_gravity="bottom"
         android:layout_marginBottom="@dimen/value_20dp"
         android:layout_marginRight="@dimen/value_20dp"
-        android:backgroundTint="@color/primaryDarkBlue"
         android:foregroundTint="@color/primaryDarkBlue"
         android:scaleType="center"
         android:visibility="gone"


### PR DESCRIPTION
Fixes #242 

**Summary**
Removing android:backgroundTint resolved the bug.
android:backgroundTint is only used in API level 21 and higher (current min is 15)

**GIF**
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/30550059/54601439-06ef2900-4a65-11e9-97bb-57f22352e036.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


