### PR TITLE
fix : Removed suspicious parameter name combination in GenerateQr.java file

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/qr/domain/usecase/GenerateQr.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/qr/domain/usecase/GenerateQr.java
@@ -21,6 +21,7 @@ public class GenerateQr extends UseCase<GenerateQr.RequestValues, GenerateQr.Res
     private static final int WHITE = 0xFFFFFFFF;
     private static final int BLACK = 0xFF000000;
     private static final int WIDTH = 500;
+    private static final int HEIGHT = 500;
 
     @Inject
     public GenerateQr() {
@@ -47,7 +48,7 @@ public class GenerateQr extends UseCase<GenerateQr.RequestValues, GenerateQr.Res
         BitMatrix result;
         try {
             result = new MultiFormatWriter().encode(str,
-                    BarcodeFormat.QR_CODE, WIDTH, WIDTH, null);
+                    BarcodeFormat.QR_CODE, WIDTH, HEIGHT, null);
         } catch (IllegalArgumentException iae) {
             return null;
         }


### PR DESCRIPTION
Fixes #515 

**Summary**
Changed the fourth parameter name to HEIGHT (before it was WIDTH) in MultiFormatWriter.encode()
 method to remove suspicious parameter name combination warnings.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


