### PR TITLE
Fix: Removed Unused namespace declarations in XML files

### DIFF
--- a/mifospay/src/main/res/layout/dialog_choose_signup_method.xml
+++ b/mifospay/src/main/res/layout/dialog_choose_signup_method.xml
@@ -2,7 +2,6 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 

--- a/mifospay/src/main/res/layout/fragment_kyc.xml
+++ b/mifospay/src/main/res/layout/fragment_kyc.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
Fixes #533 

**Summary**
Removed unused namespace declaration in XML files that are found in `dialog_choose_signup_method.xml` and `fragment_kyc.xml`.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


