### PR TITLE
fix: added firebase:core dependency in build/mifospay to eliminate warnings

### DIFF
--- a/mifospay/build.gradle
+++ b/mifospay/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     implementation 'com.mifos.mobile:mifos-passcode:0.3.0'
     implementation 'com.google.firebase:firebase-messaging:17.3.4'
     implementation 'com.google.android.gms:play-services-auth:16.0.1'
+    implementation 'com.google.firebase:firebase-core:16.0.1'
 
     implementation 'com.hbb20:ccp:2.2.0'
     implementation 'com.github.MdFarhanRaja:SearchableSpinner:1.9'


### PR DESCRIPTION
Fixes #565 
The build was earlier lacking  firebase:core dependency and hence it gave those warning. After adding the dependency, the build is now clean without any warnings or errors

Please make sure these boxes are checked before submitting your pull request - thanks!

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


