### PR TITLE
fix: Removed hint after clicking on mobile number iin EditProfile

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
@@ -188,8 +188,6 @@ public class EditProfileActivity extends BaseActivity implements
     public void onUserDetailsFocusChanged(EditText input, boolean isFocused) {
         if (!isDataSaveNecessary((input))) {
             if (isFocused) {
-                input.setText(input.getHint().toString());
-            } else {
                 input.getText().clear();
             }
         }


### PR DESCRIPTION
Fixes #582 
Removed the hints after clicking on mobile number by editing in EditProfile.java 

![12](https://user-images.githubusercontent.com/37215508/70385920-37427300-19b8-11ea-8797-cd6f5a8c8178.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


