### PR TITLE
fix: removed hints after mobile number is pressed in EditProfile

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
@@ -186,12 +186,8 @@ public class EditProfileActivity extends BaseActivity implements
     @OnFocusChange({R.id.et_edit_profile_username, R.id.et_edit_profile_email,
             R.id.et_edit_profile_vpa, R.id.et_edit_profile_mobile})
     public void onUserDetailsFocusChanged(EditText input, boolean isFocused) {
-        if (!isDataSaveNecessary((input))) {
-            if (isFocused) {
-                input.setText(input.getHint().toString());
-            } else {
-                input.getText().clear();
-            }
+        if (!isDataSaveNecessary((input)) && (!isFocused)) {
+            input.setText(input.getHint().toString());
         }
     }
 


### PR DESCRIPTION
Fixes #582 
Removed the hints when the mobile number is clicked

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


