### PR TITLE
fix: added toasts when user changes or removes profile picture

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
@@ -20,6 +20,7 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import com.hbb20.CountryCodePicker;
 import com.yalantis.ucrop.UCrop;
@@ -329,6 +330,8 @@ public class EditProfileActivity extends BaseActivity implements
 
     @Override
     public void removeProfileImage() {
+        Toast.makeText(this,R.string.toast_profile_removed,Toast.LENGTH_SHORT).show();
+
         // TODO: Remove image from database
     }
 
@@ -364,6 +367,7 @@ public class EditProfileActivity extends BaseActivity implements
         if (resultUri != null) {
             ivUserImage.setImageURI(resultUri);
         }
+        Toast.makeText(this,R.string.toast_profile_changed,Toast.LENGTH_SHORT).show();
     }
 
     @Override

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -234,5 +234,7 @@
     <string name="password_very_strong">Very Strong</string>
     <string name="amount">Amount</string>
     <string name="merchant_history_message">The transaction history with this merchant will be shown here</string>
+    <string name="toast_profile_removed">Profile picture removed</string>
+    <string name="toast_profile_changed">Profile picture changed</string>
     <string name="log_out_title">Do you want to logout?</string>
 </resources>


### PR DESCRIPTION
Fixes #599 

added toasts when the user either changes or removes profile picture

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


