### PR TITLE
fix: added toast when user removes profile picture

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
@@ -332,7 +332,7 @@ public class EditProfileActivity extends BaseActivity implements
 
     @Override
     public void removeProfileImage() {
-        Toast.makeText(this,R.string.toast_profile_removed,Toast.LENGTH_SHORT).show();
+        Toast.makeText(this, R.string.toast_profile_removed, Toast.LENGTH_SHORT).show();
         // TODO: Remove image from database
     }
 
@@ -368,7 +368,6 @@ public class EditProfileActivity extends BaseActivity implements
         if (resultUri != null) {
             ivUserImage.setImageURI(resultUri);
         }
-
     }
 
     @Override

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
@@ -19,6 +19,7 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import com.hbb20.CountryCodePicker;
 import com.yalantis.ucrop.UCrop;
@@ -331,6 +332,7 @@ public class EditProfileActivity extends BaseActivity implements
 
     @Override
     public void removeProfileImage() {
+        Toast.makeText(this,R.string.toast_profile_removed,Toast.LENGTH_SHORT).show();
         // TODO: Remove image from database
     }
 
@@ -366,6 +368,7 @@ public class EditProfileActivity extends BaseActivity implements
         if (resultUri != null) {
             ivUserImage.setImageURI(resultUri);
         }
+
     }
 
     @Override

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -244,5 +244,6 @@
     <string name="set_amount">Set Amount</string>
     <string name="grip">Grip</string>
     <string name="hide_balance">Hide Balance</string>
+    <string name="toast_profile_removed">Profile picture removed</string>
 
 </resources>


### PR DESCRIPTION
Fixes #599 

Added toasts when the user removes profile picture

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


