### PR TITLE
fix: new password can't be the same as old password toast

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/password/presenter/EditPasswordPresenter.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/password/presenter/EditPasswordPresenter.java
@@ -44,7 +44,10 @@ public class EditPasswordPresenter implements EditPasswordContract.EditPasswordP
         mEditPasswordView.startProgressBar();
         if (isNotEmpty(currentPassword) && isNotEmpty(newPassword)
                 && isNotEmpty(newPasswordRepeat)) {
-            if (isNewPasswordValid(newPassword, newPasswordRepeat)) {
+            if (currentPassword.equals(newPassword)) {
+                mEditPasswordView.stopProgressBar();
+                mEditPasswordView.showError(Constants.ERROR_PASSWORDS_CANT_BE_SAME);
+            } else if (isNewPasswordValid(newPassword, newPasswordRepeat)) {
                 updatePassword(currentPassword, newPassword);
             } else {
                 mEditPasswordView.stopProgressBar();

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
@@ -181,6 +181,8 @@ public class Constants {
 
     public static final String ERROR_FIELDS_CANNOT_BE_EMPTY = "Fields cannot be empty";
     public static final String ERROR_VALIDATING_PASSWORD = "Passwords are not the same";
+    public static final String ERROR_PASSWORDS_CANT_BE_SAME =
+            "New password can't be the same as old password.";
 
     public static final String CHANGE_PROFILE_IMAGE_KEY = "CHANGE_PROFILE_IMAGE_KEY";
     public static final String CHANGE_PROFILE_IMAGE_VALUE = "CHANGE_PROFILE_IMAGE_VALUE";


### PR DESCRIPTION
## Issue Fix
Fixes #612 

## Description
Added a toast which shows up if the user enters the same password as the new password.

##
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


