### PR TITLE
Fix: Add non-integers in mobile number

### DIFF
--- a/mifospay/src/main/res/layout/fragment_send.xml
+++ b/mifospay/src/main/res/layout/fragment_send.xml
@@ -171,7 +171,7 @@
                         android:layout_height="match_parent"
                         android:paddingBottom="@dimen/value_10dp"
                         android:hint="@string/mobile_number"
-                        android:inputType="phone|number"
+                        android:inputType="number"
                         android:singleLine="true"
                         android:textAlignment="center"
                         android:textSize="@dimen/value_15sp"


### PR DESCRIPTION
Fixes #632 

## GIF:
![ezgif com-video-to-gif (11)](https://user-images.githubusercontent.com/44428198/71635845-3a92ec80-2c4e-11ea-85c8-17e4fff0ce12.gif)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


