### PR TITLE
fix: Edit Profile dialog crashes when dismissed without any changes.

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/DialogBox.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/DialogBox.java
@@ -42,6 +42,7 @@ public class DialogBox {
 
 
     public void dismiss() {
-        alertDialog.dismiss();
+        if (alertDialog != null)
+            alertDialog.dismiss();
     }
 }


### PR DESCRIPTION
When you open the edit Profile Dialog box, and then immediately dismiss it (don't make any profile changes), the app crashes because of a NullPointerException. This PR fixes this bug. Please refer #643 for more.

Please Add Screenshots If any UI changes.
![untitled](https://user-images.githubusercontent.com/25480443/72032171-a7446180-32b4-11ea-8de2-f70f8a7181d7.gif)

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything
- [x] If you have multiple commits please combine them into one commit by squashing them.