### PR TITLE
feat: added travis CI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ Before you begin, you should have already downloaded the Android Studio SDK and 
 `git checkout dev`
 `git pull upstream dev`
 
+## Travis CI
+<a href="https://travis-ci.com">Travis CI</a> is a hosted continuous integration service used to build and test software projects hosted at GitHub. We use Travis CI for continous integration and clean maintainence of code. All your pull requests must pass the CI build only then, it will be allowed to merge. Sometimes,when the build doesn't pass you can use these commands in your local terminal and check for the errors,</br>
+
+For Mac OS, you can use the following commands:
+* `./gradlew check` quality checks on your project’s code using Checkstyle and generates reports from these checks.</br>
+* `./gradlew spotlessApply` an check and apply formatting to any plain-text file.</br>
+* `./gradlew build`  provides a command line to execute build script.</br>
+
+For Windows, you can use the following commands:
+* `gradlew check` quality checks on your project’s code using Checkstyle and generates reports from these checks.</br>
+* `gradlew spotlessApply` an check and apply formatting to any plain-text file.</br>
+* `gradlew build`  provides a command line to execute build script.</br>
+
+
+
+
+
+
+
+
+
 
 ## Wiki
 


### PR DESCRIPTION
Fixes #618
Added travis CI commands for new contributors to help when they stuck on travis errors

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


