### PR TITLE
fix : limiting OTP length to 6

### DIFF
--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -129,7 +129,8 @@
                 android:inputType="number"
                 android:paddingLeft="15dp"
                 android:paddingRight="15dp"
-                android:visibility="gone"/>
+                android:visibility="gone"
+                android:maxLength="6"/>
 
             <ProgressBar
                 android:id="@+id/progressBar"


### PR DESCRIPTION
Fixes #656 

The maximum length of OTP is fixed to 6.

![Screenshot_20200119-142748_Mifos Pay](https://user-images.githubusercontent.com/22510309/72737889-77576100-3bc6-11ea-8c21-1fe516450abc.jpg)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


