### PR TITLE
 changed the color of back arrow to white

### DIFF
--- a/mifospay/src/main/res/drawable/ic_arrow_back.xml
+++ b/mifospay/src/main/res/drawable/ic_arrow_back.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:fillColor="@color/colorBlack87"
+      android:fillColor="@color/white"
       android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
 </vector>


### PR DESCRIPTION
Fixes #695

Changed the color of the back arrow from black to white.

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


