### PR TITLE
fix: goes to the same page is google sign in fails

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/passcode/ui/PassCodeActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/passcode/ui/PassCodeActivity.java
@@ -58,7 +58,6 @@ public class PassCodeActivity extends MifosPassCodeActivity implements
     public void startNextActivity() {
         // authenticate user with saved Preferences
         mPresenter.createAuthenticatedService();
-
         Intent intent = new Intent(PassCodeActivity.this, MainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP |
                 Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);


### PR DESCRIPTION
Fixes #701 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37215508/73856668-d3271880-485b-11ea-9b8b-a26903ce572f.gif)
 Added intent to go back to login page if the google login fails

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


