### PR TITLE
 fix: returns to the previous page if google sign in not verified

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/auth/ui/LoginActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/auth/ui/LoginActivity.java
@@ -184,7 +184,7 @@ public class LoginActivity extends BaseActivity implements AuthContract.LoginVie
                 DebugUtil.log(Constants.GOOGLE_SIGN_IN_FAILED, e.getMessage());
                 Toaster.showToast(this, Constants.GOOGLE_SIGN_IN_FAILED);
                 hideProgressDialog();
-                signup(mMifosSavingProductId);
+                startActivity(new Intent(LoginActivity.this, LoginActivity.class));
             }
         }
     }


### PR DESCRIPTION
Fixes #705 

Added code when google sign in fails, it leads to the same activity

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


