### PR TITLE
 fix: app crash when user ddint enter a mobile number

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/MobileVerificationActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/MobileVerificationActivity.java
@@ -73,7 +73,6 @@ public class MobileVerificationActivity extends BaseActivity implements
 
     @OnClick(R.id.btn_get_otp)
     public void onGetOTp() {
-        Utils.hideSoftKeyboard(this);
         if (mCcpCode.isValidFullNumber()) {
             showProgressDialog(Constants.SENDING_OTP_TO_YOUR_MOBILE_NUMBER);
 
@@ -102,7 +101,6 @@ public class MobileVerificationActivity extends BaseActivity implements
         mEtOtp.setVisibility(View.VISIBLE);
         mBtnGetOtp.setClickable(false);
         mBtnGetOtp.setBackgroundResource(R.drawable.ic_done);
-        mFabNext.setVisibility(View.VISIBLE);
     }
 
     @Override


### PR DESCRIPTION
Fixes #703 
Fixed app crash when mobile number not entered in register activity

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.


