### PR TITLE
Fix #738: Impartial text displayed to the bottom of Login Screen

### DIFF
--- a/mifospay/src/main/res/layout/activity_login.xml
+++ b/mifospay/src/main/res/layout/activity_login.xml
@@ -83,7 +83,7 @@
     <LinearLayout
         android:id="@+id/ll_signup"
         android:layout_width="0dp"
-        android:layout_height="16dp"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/marginItemsInSectionLarge"
         android:gravity="center_horizontal"
         android:orientation="horizontal"


### PR DESCRIPTION
## Issue Fix
Fixes #738 The text **Don't have an account? Create one**  to the bottom of the login screen is now completely displayed

## Screenshots

![fix - don't have account text displayed impartially](https://user-images.githubusercontent.com/30969403/75049038-84ca7880-54ef-11ea-880d-bc1716137d9c.jpg)

## Please make sure these boxes are checked before submitting your pull request - thanks

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
