### PR TITLE
Fix #731: Add account button text not visible completely

### DIFF
--- a/mifospay/src/main/res/layout/fragment_accounts.xml
+++ b/mifospay/src/main/res/layout/fragment_accounts.xml
@@ -35,7 +35,7 @@
 
     <android.support.design.chip.Chip
         android:id="@+id/addaccountbutton"
-        android:layout_width="155dp"
+        android:layout_width="wrap_content"
         app:chipBackgroundColor="@color/black"
         android:layout_height="35dp"
         android:layout_alignParentBottom="true"


### PR DESCRIPTION
## Issue Fix
Fixes #731 **Add Account** text in Account Fragment is now completely visible on long displays

## Screenshots

![fix - add account button not visible](https://user-images.githubusercontent.com/30969403/75049509-539e7800-54f0-11ea-8bc0-bd428731cf55.jpg)


## Please make sure these boxes are checked before submitting your pull request - thanks

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
