### PR TITLE
Fix #774 - bottom navigation bar does not move up with the keyboard

### DIFF
--- a/mifospay/src/main/AndroidManifest.xml
+++ b/mifospay/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         </activity>
         <activity
             android:name=".home.ui.MainActivity"
+            android:windowSoftInputMode="adjustPan"
             android:theme="@style/AppTheme" />
         <activity
             android:name=".history.ui.TransactionsHistoryActivity"


### PR DESCRIPTION
Fix #774


## Screenshots
<img src="https://user-images.githubusercontent.com/30518564/75516876-66023f80-5a23-11ea-8a65-8c3d90fe00df.jpg" height="60%" width="60%">



- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
