### PR TITLE
fix: shows message when user doesnt enter any amount

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/qr/ui/ShowQrActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/qr/ui/ShowQrActivity.java
@@ -90,7 +90,7 @@ public class ShowQrActivity extends BaseActivity implements QrContract.ShowQrVie
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 String amount = edittext.getText().toString();
-                if (amount.equals("")) {
+                if (amount.isEmpty()) {
                     showToast("Please enter the Amount");
                     return;
                 } else if (Double.parseDouble(amount) <= 0) {


### PR DESCRIPTION
Fixes: #728
Altered the condition when QRActivity shows pop up message when no amount is displayed/given

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.
