### PR TITLE
Fix #788 - added option to view receipt when downloaded

### DIFF
--- a/mifospay/src/main/AndroidManifest.xml
+++ b/mifospay/src/main/AndroidManifest.xml
@@ -60,6 +60,15 @@
                     android:scheme="https" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="org.mifos.mobilewallet.mifospay.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
         <activity
             android:name=".invoice.ui.InvoiceActivity"
             android:theme="@style/AppTheme"

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/receipt/presenter/ReceiptPresenter.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/receipt/presenter/ReceiptPresenter.java
@@ -53,7 +53,6 @@ public class ReceiptPresenter implements ReceiptContract.ReceiptPresenter {
                     public void onSuccess(DownloadTransactionReceipt.ResponseValue response) {
                         mReceiptView.writeReceiptToPDF(response.getResponseBody(),
                                 Constants.RECEIPT + transactionId + Constants.PDF);
-                        mReceiptView.showSnackbar(Constants.RECEIPT_DOWNLOADED_SUCCESSFULLY);
                     }
 
                     @Override

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/receipt/ui/ReceiptActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/receipt/ui/ReceiptActivity.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.net.Uri;
@@ -11,8 +12,10 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.content.FileProvider;
 import android.view.View;
 import android.widget.TextView;
 
@@ -195,12 +198,33 @@ public class ReceiptActivity extends BaseActivity implements ReceiptContract.Rec
         if (!mifosDirectory.exists()) {
             mifosDirectory.mkdirs();
         }
-        File documentFile = new File(mifosDirectory.getPath(), filename);
+        final File documentFile = new File(mifosDirectory.getPath(), filename);
         if (!FileUtils.writeInputStreamDataToFile(responseBody.byteStream(), documentFile)) {
             showToast(Constants.ERROR_DOWNLOADING_RECEIPT);
         } else {
-            showSnackbar(Constants.RECEIPT_DOWNLOADED_SUCCESSFULLY);
+            Snackbar.make(findViewById(android.R.id.content),
+                    Constants.RECEIPT_DOWNLOADED_SUCCESSFULLY, Snackbar.LENGTH_LONG)
+                    .setAction(Constants.VIEW, new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            openFile(ReceiptActivity.this, documentFile);
+                        }
+                    })
+                    .show();
         }
+    }
+
+    private void openFile(Context context, File file) {
+        final Uri data = FileProvider.getUriForFile(context,
+                "org.mifos.mobilewallet.mifospay.provider", file);
+        context.grantUriPermission(context.getPackageName(),
+                data, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        Intent intent = new Intent(Intent.ACTION_VIEW)
+                .setDataAndType(data, "application/pdf")
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+        intent = Intent.createChooser(intent, "View Receipt");
+        context.startActivity(intent);
     }
 
     @Override

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
@@ -186,4 +186,5 @@ public class Constants {
     public static final String CHANGE_PROFILE_IMAGE_VALUE = "CHANGE_PROFILE_IMAGE_VALUE";
     public static final String TAP_TO_REVEAL = "Tap to Reveal";
     public static final String NAME = "Name : ";
+    public static final String VIEW = "View";
 }

--- a/mifospay/src/main/res/xml/provider_paths.xml
+++ b/mifospay/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,3 @@
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="mifospay/"/>
+</paths>


### PR DESCRIPTION
Fix #788

![Screenrecorder-2020-03-03-22-56](https://user-images.githubusercontent.com/30518564/75802368-9e4aaa80-5da2-11ea-9513-62eccb72d8bf.gif)


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
