### PR TITLE
Fixed app crash when submitting null amount in MerchantTransferActivity

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/merchants/ui/MerchantTransferActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/merchants/ui/MerchantTransferActivity.java
@@ -139,12 +139,14 @@ public class MerchantTransferActivity extends BaseActivity implements
         String externalId = tvMerchantVPA.getText().toString().trim();
         String eamount = etAmount.getText().toString().trim();
 
-        double amount = Double.parseDouble(eamount);
-        if (amount <= 0) {
-            showToast(Constants.PLEASE_ENTER_VALID_AMOUNT);
-            return;
-        }
-        mTransferPresenter.checkBalanceAvailability(externalId, amount);
+        if (!TextUtils.isEmpty(eamount)) {
+                double amount = Double.parseDouble(eamount);
+                if (amount <= 0) {
+                    showToast(Constants.PLEASE_ENTER_VALID_AMOUNT);
+                    return;
+                }
+                mTransferPresenter.checkBalanceAvailability(externalId, amount);
+        } else showToast(Constants.PLEASE_ENTER_ALL_THE_FIELDS);
     }
 
     @Override


### PR DESCRIPTION
## Issue Fix
Fixes issues #794 and #757

## Description
In `org.mifos.mobilewallet.mifospay.merchants.ui.MerchantTransferActivity` when `R.id.btn_submit`  is clicked, `makeTransaction()` now checks if the amount fetched from the EditText is not null before parsing the String to a Double. It also shows the user a Toast if an amount has not been entered


##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
