### PR TITLE
Fix #822 - Cursor color now matches with the overall theme

### DIFF
--- a/mifospay/src/main/res/layout/fragment_send.xml
+++ b/mifospay/src/main/res/layout/fragment_send.xml
@@ -102,8 +102,7 @@
                     android:hint="@string/amount"
                     android:inputType="number"
                     android:paddingBottom="@dimen/value_20dp"
-                    android:textSize="@dimen/value_15sp"
-                    android:theme="@style/Theme.AppCompat.Light" />
+                    android:textSize="@dimen/value_15sp" />
             </android.support.design.widget.TextInputLayout>
 
             <LinearLayout
@@ -128,8 +127,7 @@
                         android:hint="@string/virtual_payment_address"
                         android:paddingBottom="@dimen/value_20dp"
                         android:singleLine="true"
-                        android:textSize="@dimen/value_15sp"
-                        android:theme="@style/Theme.AppCompat.Light" />
+                        android:textSize="@dimen/value_15sp" />
                 </android.support.design.widget.TextInputLayout>
 
                 <TextView
@@ -174,9 +172,8 @@
                         android:inputType="number"
                         android:singleLine="true"
                         android:textAlignment="center"
-                        android:textSize="@dimen/value_15sp"
-                        android:theme="@style/Theme.AppCompat.Light"
-                        android:maxLength="@integer/telephone_numbers_max_length_standard"/>
+                        android:maxLength="@integer/telephone_numbers_max_length_standard"
+                        android:textSize="@dimen/value_15sp" />
 
                 </android.support.design.widget.TextInputLayout>
 


### PR DESCRIPTION
Fix #822


<img src="https://user-images.githubusercontent.com/30518564/76735928-f2369580-678b-11ea-97b4-ca8d19819105.jpg" height="60%" width="60%">

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
