### PR TITLE
Fix #788 - added option to view receipt when downloaded

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/receipt/presenter/ReceiptPresenter.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/receipt/presenter/ReceiptPresenter.java
@@ -53,7 +53,6 @@ public class ReceiptPresenter implements ReceiptContract.ReceiptPresenter {
                     public void onSuccess(DownloadTransactionReceipt.ResponseValue response) {
                         mReceiptView.writeReceiptToPDF(response.getResponseBody(),
                                 Constants.RECEIPT + transactionId + Constants.PDF);
-                        mReceiptView.showSnackbar(Constants.RECEIPT_DOWNLOADED_SUCCESSFULLY);
                     }
 
                     @Override

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
@@ -188,4 +188,5 @@ public class Constants {
 
     public static final int WHITE_BACK_BUTTON = R.drawable.ic_arrow_back_white_24dp;
     public static final int BLACK_BACK_BUTTON = R.drawable.ic_arrow_back_black_24dp;
+    public static final String VIEW = "View";
 }

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Toaster.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Toaster.java
@@ -19,21 +19,26 @@ public class Toaster {
     public static final int LONG = Snackbar.LENGTH_LONG;
     public static final int SHORT = Snackbar.LENGTH_SHORT;
 
-    public static void show(View view, String text, int duration) {
+    public static void show(View view, String text, int duration, String actionText,
+                                 View.OnClickListener clickListener) {
         if (view != null) {
             final Snackbar snackbar = Snackbar.make(view, text, duration);
             View sbView = snackbar.getView();
             TextView textView = sbView.findViewById(android.support.design.R.id.snackbar_text);
             textView.setTextColor(Color.WHITE);
             textView.setTextSize(12);
-            snackbar.setAction(Constants.OK, new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    snackbar.dismiss();
-                }
-            });
+            snackbar.setAction(actionText, clickListener);
             snackbar.show();
         }
+    }
+
+    public static void show(View view, String text, int duration) {
+        show(view, text, duration, Constants.OK, new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+
+            }
+        });
     }
 
     public static void show(View view, int res, int duration) {

--- a/mifospay/src/main/res/xml/provider_paths.xml
+++ b/mifospay/src/main/res/xml/provider_paths.xml
@@ -2,5 +2,6 @@
 <resources>
     <paths xmlns:android="http://schemas.android.com/apk/res/android">
         <cache-path name="shared_codes" path="codes/"/>
+        <external-path name="external_files" path="mifospay/"/>
     </paths>
 </resources>


### PR DESCRIPTION
Fix #788

![Screenrecorder-2020-03-03-22-56](https://user-images.githubusercontent.com/30518564/75802368-9e4aaa80-5da2-11ea-9513-62eccb72d8bf.gif)


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
