### PR TITLE
fix: added link for screen shots of entire app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,7 @@ that can be used as a dependency in any other wallet based project. It is develo
 | [![Build Status](https://travis-ci.com/openMF/mobile-wallet.svg?branch=master)](https://travis-ci.com/openMF/mobile-wallet) | [![Build Status](https://travis-ci.com/openMF/mobile-wallet.svg?branch=dev)](https://travis-ci.com/openMF/mobile-wallet) | [![Join the chat at https://gitter.im/openMF/mobile-wallet](https://badges.gitter.im/openMF/mobile-wallet.svg)](https://gitter.im/openMF/mobile-wallet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) |
 
 ## Screenshots
-
-<p>
-  <img src="https://user-images.githubusercontent.com/37406965/51085243-86f2cd00-175c-11e9-9f5e-8a2324cfda4a.jpg" width="288" height="500" />
-  <img src="https://user-images.githubusercontent.com/37406965/51085245-8823fa00-175c-11e9-949a-c5292037b970.jpg" width="288" height="500" /> 
-  <img src="https://user-images.githubusercontent.com/37406965/51085246-89552700-175c-11e9-9a5b-5a85ecb5bfae.jpg" width="288" height="500" />
-</p>
+Click <a href= "https://github.com/openMF/mobile-wallet/blob/dev/Screenshot.md">here </a> for Screenshots.
 
 ## How to Contribute
 
@@ -32,7 +27,7 @@ We have the following branches :
  * **dev**
      All the contributions should be pushed to this branch. If you're making a contribution,
      you are supposed to make a pull request to _dev_.
-     Please make sure it passes a build check on Travis.
+     Please make sure it passes a build check on Travi
 
      It is advisable to clone only the development branch using the following command:
 


### PR DESCRIPTION
Fixes: #661 
Added link for the entire screen shot of the app.

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.
