### PR TITLE
fix#889 - app does not crash on tapping on background

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/auth/ui/LoginActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/auth/ui/LoginActivity.java
@@ -115,7 +115,9 @@ public class LoginActivity extends BaseActivity implements AuthContract.LoginVie
 
     @OnClick(R.id.bg_screen)
     public void backgroundScreenClicked() {
-        Utils.hideSoftKeyboard(this);
+        if (this.getCurrentFocus() != null) {
+            Utils.hideSoftKeyboard(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Issue Fix
Fixes #889 

## Screen Recording
![GIF-200411_224137](https://user-images.githubusercontent.com/46667021/79050218-3b242180-7c46-11ea-8f4f-8f37239de5f1.gif)


## Description
The application doesn't crash anymore because `Utils.hideSoftKeyboard(context)` is not called if there's no item in focus, which earlier made the application crash

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
