### PR TITLE
Shows Toast when debit card number's count is not in range of 12-19

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/presenter/DebitCardPresenter.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/presenter/DebitCardPresenter.java
@@ -1,9 +1,12 @@
 package org.mifos.mobilewallet.mifospay.bank.presenter;
 
+import org.mifos.mobilewallet.mifospay.R;
 import org.mifos.mobilewallet.mifospay.bank.BankContract;
 import org.mifos.mobilewallet.mifospay.base.BaseView;
 
 import javax.inject.Inject;
+
+import static org.mifos.mobilewallet.mifospay.MifosPayApp.getContext;
 
 /**
  * Created by ankur on 13/July/2018
@@ -27,8 +30,11 @@ public class DebitCardPresenter implements BankContract.DebitCardPresenter {
     @Override
     public void verifyDebitCard(String s, String s1, String s2) {
         String otp = "0000";
-        mDebitCardView.verifyDebitCardSuccess(otp);
-//        String message = "error";
-//        mDebitCardView.verifyDebitCardError(message);
+        if ((s.length() < 12) || (s.length() > 19)) {
+            mDebitCardView.verifyDebitCardError(getContext()
+                    .getString(R.string.debit_card_error_message));
+        } else {
+            mDebitCardView.verifyDebitCardSuccess(otp);
+        }
     }
 }

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
     <string name="disable_account">Disable account</string>
     <string name="log_out">Log out</string>
     <string name="debit_card_details">Debit Card Details</string>
+    <string name="debit_card_error_message">Invalid Debit Card Number</string>
     <string name="one_time_password">One Time Password</string>
     <string name="upi_pin_setup">UPI PIN Setup</string>
     <string name="all_fields_are_mandatory">All fields are mandatory.</string>


### PR DESCRIPTION
## Issue Fix
Fixes #857 

## Screenshots
Debit Card Number count is less than 12  : 

![lessThan12](https://user-images.githubusercontent.com/48084596/79534219-9c5d5200-8097-11ea-8ffe-c6fe9ec88e38.gif)


When Debit Card Number count is more than 19  :

![morethan19](https://user-images.githubusercontent.com/48084596/79534250-b008b880-8097-11ea-8142-fc8cfa075e42.gif)
 

When Debit Card Number is in range i.e. 12-19  :

![inRange](https://user-images.githubusercontent.com/48084596/79534297-cb73c380-8097-11ea-9b6a-42fde1511341.gif)


## Description
If the Debit Card Number entered is not sufficient i.e. not in the range 12 - 19, it will show a toast message i.e. "Invalid Debit Card".

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
