### PR TITLE
fix:LoginActivity - mifosSavingsProductId parameter not used

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/auth/ui/LoginActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/auth/ui/LoginActivity.java
@@ -198,6 +198,7 @@ public class LoginActivity extends BaseActivity implements AuthContract.LoginVie
     public void signup(int mifosSavingsProductId) {
         showProgressDialog(Constants.PLEASE_WAIT);
         Intent intent = new Intent(LoginActivity.this, MobileVerificationActivity.class);
+        mMifosSavingProductId = mifosSavingsProductId;
         intent.putExtra(Constants.MIFOS_SAVINGS_PRODUCT_ID, mMifosSavingProductId);
         if (account != null) {
             intent.putExtra(Constants.GOOGLE_PHOTO_URI, account.getPhotoUrl());


### PR DESCRIPTION
## Issue Fix
Fixes #{Issue  #953 }



## Description
Initialized mMifosSavingProductId to mifosSavingsProductId and passed to intent.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
