### PR TITLE
fix: hidden add card when they aren't fetched or show error

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/ui/CardsFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/ui/CardsFragment.java
@@ -3,6 +3,7 @@ package org.mifos.mobilewallet.mifospay.savedcards.ui;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.design.chip.Chip;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
@@ -66,6 +67,9 @@ public class CardsFragment extends BaseFragment implements CardsContract.CardsVi
 
     @Inject
     CardsAdapter mCardsAdapter;
+
+    @BindView(R.id.btn_add_card)
+    Chip addCard;
 
     View rootView;
 
@@ -143,6 +147,7 @@ public class CardsFragment extends BaseFragment implements CardsContract.CardsVi
         vStateView.setVisibility(View.GONE);
         rvCards.setVisibility(View.GONE);
         pbCards.setVisibility(View.VISIBLE);
+        addCard.setVisibility(View.GONE);
     }
 
 
@@ -248,6 +253,7 @@ public class CardsFragment extends BaseFragment implements CardsContract.CardsVi
         }
         mCardsAdapter.setCards(cards);
         hideSwipeProgress();
+        addCard.setVisibility(View.VISIBLE);
     }
 
     /**


### PR DESCRIPTION
Fixes: #834 
The "add card" option has been hidden when the cards aren't fetched. 
<img src="https://user-images.githubusercontent.com/37215508/77047710-38d5fb00-69eb-11ea-880f-3cb6f520eacf.jpg" width="250" height="500"/>


- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.
