### PR TITLE
Feat: Added support for Standing Instructions

### DIFF
--- a/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/api/ApiEndPoints.java
+++ b/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/api/ApiEndPoints.java
@@ -24,4 +24,5 @@ public class ApiEndPoints {
     public static final String TWOFACTOR = "twofactor";
     public static final String RUN_REPORT = "runreports";
     public static final String USER = "users";
+    public static final String STANDING_INSTRUCTION = "standinginstructions";
 }

--- a/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/api/FineractApiManager.java
+++ b/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/api/FineractApiManager.java
@@ -14,6 +14,7 @@ import org.mifos.mobilewallet.core.data.fineract.api.services.RunReportService;
 import org.mifos.mobilewallet.core.data.fineract.api.services.SavedCardService;
 import org.mifos.mobilewallet.core.data.fineract.api.services.SavingsAccountsService;
 import org.mifos.mobilewallet.core.data.fineract.api.services.SearchService;
+import org.mifos.mobilewallet.core.data.fineract.api.services.StandingInstructionService;
 import org.mifos.mobilewallet.core.data.fineract.api.services.ThirdPartyTransferService;
 import org.mifos.mobilewallet.core.data.fineract.api.services.TwoFactorAuthService;
 import org.mifos.mobilewallet.core.data.fineract.api.services.UserService;
@@ -55,7 +56,7 @@ public class FineractApiManager {
     private static UserService userApi;
     private static ThirdPartyTransferService thirdPartyTransferApi;
     private static NotificationService notificationApi;
-
+    private static StandingInstructionService standingInstructionService;
     private static SelfServiceApiManager sSelfInstance;
 
     public FineractApiManager() {
@@ -84,6 +85,7 @@ public class FineractApiManager {
         userApi = createApi(UserService.class);
         thirdPartyTransferApi = createApi(ThirdPartyTransferService.class);
         notificationApi = createApi(NotificationService.class);
+        standingInstructionService = createApi(StandingInstructionService.class);
     }
 
     private static <T> T createApi(Class<T> clazz) {
@@ -180,4 +182,9 @@ public class FineractApiManager {
     public NotificationService getNotificationApi() {
         return notificationApi;
     }
+
+    public StandingInstructionService getStandingInstructionApi() {
+        return standingInstructionService;
+    }
+
 }

--- a/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/api/services/StandingInstructionService.kt
+++ b/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/api/services/StandingInstructionService.kt
@@ -1,0 +1,52 @@
+package org.mifos.mobilewallet.core.data.fineract.api.services
+
+import org.mifos.mobilewallet.core.data.fineract.api.ApiEndPoints
+import org.mifos.mobilewallet.core.data.fineract.api.GenericResponse
+import org.mifos.mobilewallet.core.data.fineract.entity.Page
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.SDIResponse
+import org.mifos.mobilewallet.core.data.fineract.entity.payload.StandingInstructionPayload
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+import retrofit2.http.Query
+import rx.Observable
+
+interface StandingInstructionService {
+
+    @POST(ApiEndPoints.STANDING_INSTRUCTION)
+    fun createStandingInstruction(@Body standingInstructionPayload: StandingInstructionPayload) :
+            Observable<SDIResponse>
+
+    /**
+     * @param clientId - passed as Query to limit the response to client specific response
+     */
+    @GET(ApiEndPoints.STANDING_INSTRUCTION)
+    fun getAllStandingInstructions(@Query("clientId") clientId : Long)
+            : Observable<Page<StandingInstruction>>
+
+    @GET("${ApiEndPoints.STANDING_INSTRUCTION}/{standingInstructionId}")
+    fun getStandingInstruction(@Path("standingInstructionId") standingInstructionId: Long)
+            : Observable<StandingInstruction>
+
+    /**
+     * @param command - if command is passed as "update" then the corresponding standing instruction
+     *                  is updated. If passed as "delete" then the standing instruction is deleted.
+     *
+     * @param standingInstructionId - unique id of the standing instruction on which the operation
+     *                                will be performed.
+     */
+    @PUT("${ApiEndPoints.STANDING_INSTRUCTION}/{standingInstructionId}")
+    fun deleteStandingInstruction(
+            @Path("standingInstructionId") standingInstructionId: Long,
+            @Query("command") command: String): Observable<GenericResponse>
+
+    @PUT("${ApiEndPoints.STANDING_INSTRUCTION}/{standingInstructionId}")
+    fun updateStandingInstruction(
+            @Path("standingInstructionId") standingInstructionId: Long,
+            @Body standingInstructionPayload: StandingInstructionPayload,
+            @Query("command") command: String): Observable<GenericResponse>
+
+}

--- a/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/entity/payload/StandingInstructionPayload.kt
+++ b/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/entity/payload/StandingInstructionPayload.kt
@@ -1,0 +1,18 @@
+package org.mifos.mobilewallet.core.data.fineract.entity.payload
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class StandingInstructionPayload(var fromOfficeId : Int, var fromClientId : Int,
+                                      var fromAccountType : Int, val name : String?,
+                                      val transferType : Int, val priority : Int,
+                                      val status : Int, var fromAccountId : Long,
+                                      var toOfficeId : Int, var toClientId : Int,
+                                      var toAccountType : Int, var toAccountId : Long,
+                                      val instructionType : Int, var amount : Double,
+                                      var validFrom : String?, val recurrenceType : Int,
+                                      val recurrenceInterval : Int, val recurrenceFrequency : Int,
+                                      val locale : String?, val dateFormat : String?,
+                                      var validTill : String?, var recurrenceOnMonthDay : String?,
+                                      val monthDayFormat : String?) : Parcelable

--- a/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/entity/standinginstruction/SDIResponse.kt
+++ b/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/entity/standinginstruction/SDIResponse.kt
@@ -1,0 +1,33 @@
+package org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction
+
+import android.os.Parcel
+import android.os.Parcelable
+
+/**
+ * Created by Shivansh
+ */
+
+data class SDIResponse(val clientId : Int, val resourceId : String?) : Parcelable {
+    constructor(parcel: Parcel) : this(
+            parcel.readInt(),
+            parcel.readString())
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeInt(clientId)
+        parcel.writeString(resourceId)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<SDIResponse> {
+        override fun createFromParcel(parcel: Parcel): SDIResponse {
+            return SDIResponse(parcel)
+        }
+
+        override fun newArray(size: Int): Array<SDIResponse?> {
+            return arrayOfNulls(size)
+        }
+    }
+}

--- a/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/entity/standinginstruction/StandingInstruction.kt
+++ b/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/entity/standinginstruction/StandingInstruction.kt
@@ -1,0 +1,38 @@
+package org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction
+
+import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
+import org.mifos.mobilewallet.core.data.fineract.entity.accounts.savings.SavingAccount
+import org.mifos.mobilewallet.core.data.fineract.entity.client.Client
+import org.mifos.mobilewallet.core.data.fineract.entity.client.Status
+
+/**
+ * Created by Devansh 08/06/2020
+ */
+
+@Parcelize
+data class StandingInstruction(
+        val id: Long,
+        @SerializedName("name")
+        val name: String,
+        @SerializedName("fromClient")
+        val fromClient: Client,
+        @SerializedName("fromAccount")
+        val fromAccount: SavingAccount,
+        @SerializedName("toClient")
+        val toClient: Client,
+        @SerializedName("toAccount")
+        val toAccount: SavingAccount,
+        @SerializedName("status")
+        val status: Status,
+        @SerializedName("amount")
+        var amount: Double,
+        @SerializedName("validFrom")
+        val validFrom: List<Int>,
+        @SerializedName("validTill")
+        var validTill: List<Int>?,
+        @SerializedName("recurrenceInterval")
+        var recurrenceInterval: Int,
+        @SerializedName("recurrenceOnMonthDay")
+        val recurrenceOnMonthDay: List<Int>) : Parcelable

--- a/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/repository/FineractRepository.java
+++ b/core/src/main/java/org/mifos/mobilewallet/core/data/fineract/repository/FineractRepository.java
@@ -22,6 +22,9 @@ import org.mifos.mobilewallet.core.data.fineract.entity.payload.TransferPayload;
 import org.mifos.mobilewallet.core.data.fineract.entity.register.RegisterPayload;
 import org.mifos.mobilewallet.core.data.fineract.entity.register.UserVerify;
 import org.mifos.mobilewallet.core.data.fineract.entity.savedcards.Card;
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.SDIResponse;
+import org.mifos.mobilewallet.core.data.fineract.entity.payload.StandingInstructionPayload;
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction;
 import org.mifos.mobilewallet.core.domain.model.NewAccount;
 import org.mifos.mobilewallet.core.domain.model.NotificationPayload;
 import org.mifos.mobilewallet.core.domain.model.client.NewClient;
@@ -218,6 +221,32 @@ public class FineractRepository {
 
     public Observable<TPTResponse> makeThirdPartyTransfer(TransferPayload transferPayload) {
         return fineractApiManager.getThirdPartyTransferApi().makeTransfer(transferPayload);
+    }
+
+    public Observable<SDIResponse> createStandingInstruction(
+            StandingInstructionPayload standingInstructionPayload) {
+        return fineractApiManager.getStandingInstructionApi()
+                .createStandingInstruction(standingInstructionPayload);
+    }
+
+    public Observable<Page<StandingInstruction>> getAllStandingInstructions(long clientId) {
+        return fineractApiManager.getStandingInstructionApi().getAllStandingInstructions(clientId);
+    }
+
+    public Observable<StandingInstruction> getStandingInstruction(long standingInstructionId) {
+        return fineractApiManager.getStandingInstructionApi()
+                .getStandingInstruction(standingInstructionId);
+    }
+
+    public Observable<GenericResponse> updateStandingInstruction(long standingInstructionId,
+                              StandingInstructionPayload standingInstructionPayload) {
+        return fineractApiManager.getStandingInstructionApi().updateStandingInstruction(
+                standingInstructionId, standingInstructionPayload, "update");
+    }
+
+    public Observable<GenericResponse> deleteStandingInstruction(long standingInstruction) {
+        return fineractApiManager.getStandingInstructionApi().deleteStandingInstruction(
+                standingInstruction, "delete");
     }
 
     //self user apis

--- a/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/CreateStandingTransaction.kt
+++ b/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/CreateStandingTransaction.kt
@@ -1,0 +1,191 @@
+package org.mifos.mobilewallet.core.domain.usecase.standinginstruction
+
+import org.mifos.mobilewallet.core.base.UseCase
+import org.mifos.mobilewallet.core.data.fineract.entity.accounts.savings.SavingAccount
+import org.mifos.mobilewallet.core.data.fineract.entity.client.Client
+import org.mifos.mobilewallet.core.data.fineract.entity.client.ClientAccounts
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.SDIResponse
+import org.mifos.mobilewallet.core.data.fineract.entity.payload.StandingInstructionPayload
+import org.mifos.mobilewallet.core.data.fineract.repository.FineractRepository
+import org.mifos.mobilewallet.core.utils.Constants
+import rx.Subscriber
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import javax.inject.Inject
+
+
+class CreateStandingTransaction @Inject constructor(private val apiRepository: FineractRepository) :
+        UseCase<CreateStandingTransaction.RequestValues, CreateStandingTransaction.ResponseValue>() {
+
+    lateinit var fromClient: Client
+    lateinit var toClient: Client
+    lateinit var fromAccount: SavingAccount
+    lateinit var toAccount: SavingAccount
+
+    override fun executeUseCase(requestValues: RequestValues) {
+        apiRepository.getSelfClientDetails(requestValues.fromClientId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(object : Subscriber<Client>() {
+
+                    override fun onCompleted() {
+
+                    }
+
+                    override fun onError(e: Throwable) {
+                        useCaseCallback.onError(Constants.ERROR_FETCHING_CLIENT_DATA)
+                    }
+
+                    override fun onNext(client: Client) {
+                        fromClient = client
+                        fetchToClientData()
+                    }
+                })
+    }
+
+    private fun fetchToClientData() {
+        apiRepository.getClientDetails(requestValues.toClientId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(object : Subscriber<Client>() {
+
+                    override fun onCompleted() {
+
+                    }
+
+                    override fun onError(e: Throwable) {
+                        useCaseCallback.onError(Constants.ERROR_FETCHING_CLIENT_DATA)
+                    }
+
+                    override fun onNext(client: Client) {
+                        toClient = client
+                        fetchFromAccountDetails()
+                    }
+                })
+    }
+
+    private fun fetchFromAccountDetails() {
+        apiRepository.getSelfAccounts(requestValues.fromClientId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(object : Subscriber<ClientAccounts>() {
+                    override fun onCompleted() {
+
+                    }
+
+                    override fun onError(e: Throwable) {
+                        useCaseCallback.onError(Constants.ERROR_FETCHING_FROM_ACCOUNT)
+                    }
+
+                    override fun onNext(clientAccounts: ClientAccounts) {
+                        val accounts = clientAccounts.savingsAccounts
+                        if (accounts != null && accounts.size != 0) {
+                            var walletAccount: SavingAccount? = null
+                            for (account in accounts) {
+                                if (account.productId ==
+                                        Constants.WALLET_ACCOUNT_SAVINGS_PRODUCT_ID) {
+                                    walletAccount = account
+                                    break
+                                }
+                            }
+                            walletAccount?.let{
+                                fromAccount = walletAccount
+                                fetchToAccountDetails()
+                            }?: useCaseCallback.onError(Constants.NO_WALLET_FOUND)
+
+                        } else {
+                            useCaseCallback.onError(Constants.ERROR_FETCHING_FROM_ACCOUNT)
+                        }
+                    }
+                })
+    }
+
+    private fun fetchToAccountDetails() {
+        apiRepository.getAccounts(requestValues.toClientId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(object : Subscriber<ClientAccounts>() {
+                    override fun onCompleted() {}
+                    override fun onError(e: Throwable) {
+                        useCaseCallback.onError(Constants.ERROR_FETCHING_TO_ACCOUNT)
+                    }
+
+                    override fun onNext(clientAccounts: ClientAccounts) {
+                        val accounts = clientAccounts.savingsAccounts
+                        if (accounts != null && accounts.size != 0) {
+                            var walletAccount: SavingAccount? = null
+                            for (account in accounts) {
+                                if (account.productId ==
+                                        Constants.WALLET_ACCOUNT_SAVINGS_PRODUCT_ID) {
+                                    walletAccount = account
+                                    break
+                                }
+                            }
+                            walletAccount?.let{
+                                toAccount = walletAccount
+                                createNewStandingInstruction()
+                            }?: useCaseCallback.onError(Constants.NO_WALLET_FOUND)
+
+                        } else {
+                            useCaseCallback.onError(Constants.ERROR_FETCHING_TO_ACCOUNT)
+                        }
+                    }
+                })
+    }
+
+    private fun createNewStandingInstruction() {
+
+        val standingInstructionPayload = StandingInstructionPayload(
+                fromClient.officeId,
+                fromClient.id,
+                2,
+                "wallet standing transaction",
+                1,
+                2,
+                1,
+                fromAccount.id,
+                toClient.officeId,
+                toClient.id,
+                2,
+                toAccount.id,
+                1,
+                requestValues.amount,
+                requestValues.validFrom,
+                1,
+                requestValues.recurrenceInterval,
+                2,
+                "en",
+                "dd MM yyyy",
+                requestValues.validTill,
+                requestValues.recurrenceOnDayMonth,
+                "dd MM")
+        apiRepository.createStandingInstruction(standingInstructionPayload)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(object : Subscriber<SDIResponse>() {
+
+                    override fun onCompleted() {
+
+                    }
+
+                    override fun onError(e: Throwable) {
+                        useCaseCallback.onError(Constants.ERROR_MAKING_TRANSFER)
+                    }
+
+                    override fun onNext(sdiResponse: SDIResponse) {
+                        useCaseCallback.onSuccess(ResponseValue())
+                    }
+                })
+    }
+
+    class RequestValues(val validTill: String,
+                        val validFrom: String,
+                        val recurrenceInterval: Int,
+                        val recurrenceOnDayMonth: String,
+                        val fromClientId: Long,
+                        val toClientId: Long,
+                        val amount: Double ) : UseCase.RequestValues
+
+    class ResponseValue : UseCase.ResponseValue
+
+}

--- a/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/DeleteStandingInstruction.kt
+++ b/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/DeleteStandingInstruction.kt
@@ -1,0 +1,42 @@
+package org.mifos.mobilewallet.core.domain.usecase.standinginstruction
+
+import org.mifos.mobilewallet.core.base.UseCase
+import org.mifos.mobilewallet.core.data.fineract.api.GenericResponse
+import org.mifos.mobilewallet.core.data.fineract.repository.FineractRepository
+import rx.Subscriber
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import javax.inject.Inject
+
+/**
+ * Created by Devansh on 09/06/2020
+ */
+class DeleteStandingInstruction @Inject constructor(
+        private val apiRepository: FineractRepository) :
+        UseCase<DeleteStandingInstruction.RequestValues,
+                DeleteStandingInstruction.ResponseValue>() {
+
+    override fun executeUseCase(requestValues: RequestValues) {
+        apiRepository.deleteStandingInstruction(requestValues.standingInstructionId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(object : Subscriber<GenericResponse>() {
+
+                    override fun onCompleted() {
+
+                    }
+
+                    override fun onError(e: Throwable)
+                            = useCaseCallback.onError(e.message)
+
+                    override fun onNext(genericResponse: GenericResponse)
+                            = useCaseCallback.onSuccess(ResponseValue())
+                })
+    }
+
+    class RequestValues(val standingInstructionId: Long) :
+            UseCase.RequestValues
+
+    class ResponseValue : UseCase.ResponseValue
+
+}

--- a/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/FetchStandingInstruction.kt
+++ b/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/FetchStandingInstruction.kt
@@ -1,0 +1,43 @@
+package org.mifos.mobilewallet.core.domain.usecase.standinginstruction
+
+import org.mifos.mobilewallet.core.base.UseCase
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction
+import org.mifos.mobilewallet.core.data.fineract.repository.FineractRepository
+import rx.Subscriber
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import javax.inject.Inject
+
+/**
+ * Created by Devansh on 09/06/2020
+ */
+
+class FetchStandingInstruction @Inject constructor(private val apiRepository: FineractRepository)
+    : UseCase<FetchStandingInstruction.RequestValues, FetchStandingInstruction.ResponseValue>(){
+
+
+    override fun executeUseCase(requestValues: RequestValues) {
+        apiRepository.getStandingInstruction(requestValues.standingInstructionId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(object : Subscriber<StandingInstruction>() {
+
+                    override fun onCompleted() {
+
+                    }
+
+                    override fun onError(e: Throwable)
+                            = useCaseCallback.onError(e.message)
+
+
+                    override fun onNext(standingInstruction: StandingInstruction)
+                            = useCaseCallback.onSuccess(ResponseValue(standingInstruction))
+                })
+    }
+
+    class RequestValues(val standingInstructionId: Long) : UseCase.RequestValues
+
+    class ResponseValue(val standingInstruction: StandingInstruction)
+        : UseCase.ResponseValue
+
+}

--- a/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/GetAllStandingInstructions.kt
+++ b/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/GetAllStandingInstructions.kt
@@ -1,0 +1,45 @@
+package org.mifos.mobilewallet.core.domain.usecase.standinginstruction
+
+import org.mifos.mobilewallet.core.base.UseCase
+import org.mifos.mobilewallet.core.data.fineract.entity.Page
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction
+import org.mifos.mobilewallet.core.data.fineract.repository.FineractRepository
+import rx.Subscriber
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import javax.inject.Inject
+
+/**
+ * Created by Devansh 08/06/2020
+ */
+
+class GetAllStandingInstructions @Inject constructor(private val apiRepository: FineractRepository) :
+        UseCase<GetAllStandingInstructions.RequestValues, GetAllStandingInstructions.ResponseValue>() {
+
+
+    override fun executeUseCase(requestValues: RequestValues) {
+        apiRepository.getAllStandingInstructions(requestValues.clientId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(object : Subscriber<Page<StandingInstruction>>() {
+
+                    override fun onCompleted() {
+
+                    }
+
+                    override fun onError(e: Throwable) =
+                            useCaseCallback.onError(e.message)
+
+
+                    override fun onNext(standingInstructionPage: Page<StandingInstruction>)
+                            = useCaseCallback.onSuccess(ResponseValue(standingInstructionPage.pageItems))
+
+                })
+    }
+
+    class RequestValues(val clientId: Long) : UseCase.RequestValues
+
+    class ResponseValue(val standingInstructionsList: List<StandingInstruction>)
+        : UseCase.ResponseValue
+
+}

--- a/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/UpdateStandingInstruction.kt
+++ b/core/src/main/java/org/mifos/mobilewallet/core/domain/usecase/standinginstruction/UpdateStandingInstruction.kt
@@ -1,0 +1,79 @@
+package org.mifos.mobilewallet.core.domain.usecase.standinginstruction
+
+import org.mifos.mobilewallet.core.base.UseCase
+import org.mifos.mobilewallet.core.data.fineract.api.GenericResponse
+import org.mifos.mobilewallet.core.data.fineract.entity.payload.StandingInstructionPayload
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction
+import org.mifos.mobilewallet.core.data.fineract.repository.FineractRepository
+import rx.Subscriber
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import javax.inject.Inject
+
+/**
+ * Created by Devansh on 09/06/2020
+ */
+class UpdateStandingInstruction @Inject constructor(
+        private val apiRepository: FineractRepository) :
+        UseCase<UpdateStandingInstruction.RequestValues,
+                UpdateStandingInstruction.ResponseValue>() {
+
+    override fun executeUseCase(requestValues: RequestValues) {
+        val validTillString = "${requestValues.standingInstruction.validTill?.get(2)} " +
+                "${requestValues.standingInstruction.validTill?.get(1)} " +
+                "${requestValues.standingInstruction.validTill?.get(0)}"
+        val validFromString = "${requestValues.standingInstruction.validFrom[2]} " +
+                "${requestValues.standingInstruction.validFrom[1]} " +
+                "${requestValues.standingInstruction.validFrom[0]}"
+        val recurrenceOnMonthDayString = "${requestValues.standingInstruction.validFrom[2]} " +
+                "${requestValues.standingInstruction.validFrom[1]}"
+
+        val standingInstructionPayload = StandingInstructionPayload(
+                requestValues.standingInstruction.fromClient.officeId,
+                requestValues.standingInstruction.fromClient.id,
+                2,
+                "wallet standing transaction",
+                1,
+                2,
+                1,
+                requestValues.standingInstruction.fromAccount.id,
+                requestValues.standingInstruction.toClient.officeId,
+                requestValues.standingInstruction.toClient.id,
+                2,
+                requestValues.standingInstruction.toAccount.id,
+                1,
+                requestValues.standingInstruction.amount,
+                validFromString,
+                1,
+                1,
+                2,
+                "en",
+                "dd MM yyyy",
+                validTillString,
+                recurrenceOnMonthDayString,
+                "dd MM")
+
+        apiRepository.updateStandingInstruction(requestValues.standingInstructionId,
+                standingInstructionPayload)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(object : Subscriber<GenericResponse>() {
+
+                    override fun onCompleted() {
+
+                    }
+
+                    override fun onError(e: Throwable)
+                            = useCaseCallback.onError(e.message)
+
+                    override fun onNext(genericResponse: GenericResponse)
+                            = useCaseCallback.onSuccess(ResponseValue())
+                })
+    }
+
+    class RequestValues(val standingInstructionId: Long,
+                        val standingInstruction: StandingInstruction) : UseCase.RequestValues
+
+    class ResponseValue : UseCase.ResponseValue
+
+}

--- a/mifospay/src/main/AndroidManifest.xml
+++ b/mifospay/src/main/AndroidManifest.xml
@@ -16,31 +16,36 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".merchants.ui.MerchantTransferActivity"></activity>
-
-	<activity
+        <activity android:name=".standinginstruction.ui.SIDetailsActivity"></activity>
+        <activity
+            android:name=".standinginstruction.ui.NewSIActivity"
+            android:label="@string/title_activity_new_si"
+            android:theme="@style/AppTheme.NoActionBar" />
+        <activity android:name=".merchants.ui.MerchantTransferActivity" />
+        <activity
             android:name=".SplashScreenActivity"
             android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        
-	<activity
+        <activity
             android:name=".auth.ui.LoginActivity"
             android:theme="@style/AppTheme"
             android:windowSoftInputMode="stateVisible" />
         <activity
             android:name=".home.ui.MainActivity"
-            android:windowSoftInputMode="adjustPan"
-            android:theme="@style/AppTheme" />
+            android:theme="@style/AppTheme"
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".common.ui.SearchActivity"
             android:theme="@style/AppTheme" />
         <activity
             android:name=".qr.ui.ShowQrActivity"
             android:theme="@style/AppTheme" />
+
         <provider
             android:name="android.support.v4.content.FileProvider"
             android:authorities="org.mifos.mobilewallet.mifospay.provider"
@@ -50,6 +55,7 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
+
         <activity
             android:name=".qr.ui.ReadQrActivity"
             android:theme="@style/AppTheme" />
@@ -58,8 +64,8 @@
             android:theme="@style/AppTheme" />
         <activity
             android:name=".receipt.ui.ReceiptActivity"
-            android:theme="@style/AppTheme"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:theme="@style/AppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -73,8 +79,8 @@
         </activity>
         <activity
             android:name=".invoice.ui.InvoiceActivity"
-            android:theme="@style/AppTheme"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:theme="@style/AppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/PaymentsFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/PaymentsFragment.java
@@ -15,6 +15,7 @@ import org.mifos.mobilewallet.mifospay.home.adapter.TabLayoutAdapter;
 import org.mifos.mobilewallet.mifospay.invoice.ui.InvoicesFragment;
 import org.mifos.mobilewallet.mifospay.payments.ui.RequestFragment;
 import org.mifos.mobilewallet.mifospay.payments.ui.SendFragment;
+import org.mifos.mobilewallet.mifospay.standinginstruction.ui.SIFragment;
 import org.mifos.mobilewallet.mifospay.utils.Utils;
 
 import butterknife.BindView;
@@ -78,6 +79,7 @@ public class PaymentsFragment extends BaseFragment {
         tabLayoutAdapter.addFragment(new SendFragment(), getString(R.string.send));
         tabLayoutAdapter.addFragment(new RequestFragment(), getString(R.string.request));
         tabLayoutAdapter.addFragment(new HistoryFragment(), getString(R.string.history));
+        tabLayoutAdapter.addFragment(new SIFragment(), getString(R.string.standing_instruction));
         tabLayoutAdapter.addFragment(new InvoicesFragment(), getString(R.string.invoices));
         vpTabLayout.setAdapter(tabLayoutAdapter);
     }

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/injection/component/ActivityComponent.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/injection/component/ActivityComponent.java
@@ -41,6 +41,9 @@ import org.mifos.mobilewallet.mifospay.registration.ui.MobileVerificationActivit
 import org.mifos.mobilewallet.mifospay.registration.ui.SignupActivity;
 import org.mifos.mobilewallet.mifospay.savedcards.ui.CardsFragment;
 import org.mifos.mobilewallet.mifospay.settings.ui.SettingsActivity;
+import org.mifos.mobilewallet.mifospay.standinginstruction.ui.NewSIActivity;
+import org.mifos.mobilewallet.mifospay.standinginstruction.ui.SIDetailsActivity;
+import org.mifos.mobilewallet.mifospay.standinginstruction.ui.SIFragment;
 
 import dagger.Component;
 
@@ -125,4 +128,10 @@ public interface ActivityComponent {
     void inject(NotificationActivity notificationActivity);
 
     void inject(MerchantTransferActivity merchantTransferActivity);
+
+    void inject (NewSIActivity newSIActivity);
+
+    void inject (SIFragment siFragment);
+
+    void inject (SIDetailsActivity siDetailsActivity);
 }

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/StandingInstructionContract.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/StandingInstructionContract.kt
@@ -1,0 +1,74 @@
+package org.mifos.mobilewallet.mifospay.standinginstruction
+
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction
+import org.mifos.mobilewallet.mifospay.base.BasePresenter
+import org.mifos.mobilewallet.mifospay.base.BaseView
+
+interface StandingInstructionContract {
+
+    interface NewSIPresenter : BasePresenter {
+
+        fun fetchClient(externalId: String)
+
+        fun createNewSI(toClientId: Long, amount: Double, recurrenceInterval: Int,
+                        validTill: String)
+
+    }
+
+    interface StandingInstructionsPresenter : BasePresenter {
+
+        fun getAllSI()
+
+    }
+
+    interface StandingInstructorDetailsPresenter : BasePresenter {
+
+        fun fetchStandingInstructionDetails(standingInstructionId: Long)
+
+        fun deleteStandingInstruction(standingInstructionId: Long)
+
+        fun updateStandingInstruction(standingInstruction: StandingInstruction)
+
+    }
+
+    interface NewSIView : BaseView<NewSIPresenter> {
+
+        fun showClientDetails(clientId: Long, name: String, externalId: String)
+
+        fun showSuccess(message: String)
+
+        fun showLoadingView()
+
+        fun showFailureCreatingNewSI(message: String)
+
+        fun showFailureSearchingClient(message: String)
+
+    }
+
+    interface SIListView : BaseView<StandingInstructionsPresenter> {
+
+        fun showLoadingView()
+
+        fun showStandingInstructions(standingInstructionList: List<StandingInstruction>)
+
+        fun showStateView(drawable: Int, errorTitle: Int, errorMessage: Int)
+
+    }
+
+    interface SIDetailsView : BaseView<StandingInstructorDetailsPresenter> {
+
+        fun showLoadingView()
+
+        fun showSIDetails(standingInstruction: StandingInstruction)
+
+        fun showStateView(drawable: Int, errorTitle: Int, errorMessage: Int)
+
+        fun siDeletedSuccessfully()
+
+        fun updateDeleteFailure()
+
+        fun showToast(message: String)
+
+    }
+
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/adapter/StandingInstructionAdapter.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/adapter/StandingInstructionAdapter.kt
@@ -1,0 +1,69 @@
+package org.mifos.mobilewallet.mifospay.standinginstruction.adapter
+
+import android.content.Context
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction
+import org.mifos.mobilewallet.mifospay.R
+import org.mifos.mobilewallet.mifospay.utils.Constants
+
+/**
+ * Created by Devansh on 08/06/2020
+ */
+class StandingInstructionAdapter(private val context: Context) :
+        RecyclerView.Adapter<StandingInstructionAdapter.ViewHolder>() {
+
+    private var standingInstructions: List<StandingInstruction>?= null
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val v: View = LayoutInflater.from(parent.context).inflate(
+                R.layout.item_si, parent, false)
+        return ViewHolder(v, context)
+    }
+
+    class ViewHolder(itemView: View, val context: Context) : RecyclerView.ViewHolder(itemView) {
+
+        fun bindItems(standingInstruction: StandingInstruction) {
+            val tvFromClientName = itemView.findViewById(R.id.tv_from_client_name) as TextView
+            val tvToClientName = itemView.findViewById(R.id.tv_to_client_name) as TextView
+            val tvValidTill  = itemView.findViewById(R.id.tv_valid_till_date) as TextView
+            val tvAmount  = itemView.findViewById(R.id.tv_amount) as TextView
+
+            tvFromClientName.text = context.resources.getString(R.string.from_client_name,
+                    standingInstruction.fromClient.displayName)
+            tvToClientName.text = context.resources.getString(R.string.to_client_name,
+                    standingInstruction.toClient.displayName)
+            /**
+             * Using hardcoded Currency as response doesn't return the currency
+             */
+            tvAmount.text = context.resources.getString(R.string.currency_amount,
+                    Constants.RUPEE, standingInstruction.amount.toString())
+
+            val validTill  = context.resources.getString(R.string.date_formatted,
+                    standingInstruction.validTill?.get(2).toString(),
+                    standingInstruction.validTill?.get(2).toString(),
+                    standingInstruction.validTill?.get(2).toString())
+            tvValidTill.text = context.getString(R.string.valid_till_date, validTill)
+        }
+    }
+
+    fun setData(standingInstructions: List<StandingInstruction>) {
+        this.standingInstructions = standingInstructions
+        notifyDataSetChanged()
+    }
+
+    fun getStandingInstruction(position: Int) = standingInstructions?.get(position)
+
+    override fun getItemCount(): Int =
+        standingInstructions?.let {
+            it.size
+        }?:0
+
+    override fun onBindViewHolder(viewHolder: ViewHolder, position: Int) {
+        standingInstructions?.get(position)?.let { viewHolder.bindItems(it) }
+    }
+
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/presenter/NewSIPresenter.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/presenter/NewSIPresenter.kt
@@ -1,0 +1,80 @@
+package org.mifos.mobilewallet.mifospay.standinginstruction.presenter
+
+import org.mifos.mobilewallet.core.base.UseCase.UseCaseCallback
+import org.mifos.mobilewallet.core.base.UseCaseHandler
+import org.mifos.mobilewallet.core.domain.model.SearchResult
+import org.mifos.mobilewallet.core.domain.usecase.client.SearchClient
+import org.mifos.mobilewallet.core.domain.usecase.standinginstruction.CreateStandingTransaction
+import org.mifos.mobilewallet.mifospay.base.BaseView
+import org.mifos.mobilewallet.mifospay.data.local.PreferencesHelper
+import org.mifos.mobilewallet.mifospay.standinginstruction.StandingInstructionContract
+import java.text.SimpleDateFormat
+import java.util.*
+import javax.inject.Inject
+
+/**
+ * Created by Shivansh
+ */
+class NewSIPresenter @Inject constructor (val mUseCaseHandler: UseCaseHandler,
+                                          val preferencesHelper: PreferencesHelper)
+    : StandingInstructionContract.NewSIPresenter {
+
+    lateinit var mNewSIView: StandingInstructionContract.NewSIView
+
+    @Inject
+    lateinit var searchClient: SearchClient
+
+    @Inject
+    lateinit var createStandingTransaction: CreateStandingTransaction
+
+    override fun attachView(baseView: BaseView<*>?) {
+        mNewSIView = baseView as StandingInstructionContract.NewSIView
+        mNewSIView.setPresenter(this)
+    }
+
+    override fun fetchClient(externalId: String) {
+        mNewSIView.showLoadingView()
+        mUseCaseHandler.execute(searchClient, SearchClient.RequestValues(externalId),
+                object : UseCaseCallback<SearchClient.ResponseValue> {
+
+                    override fun onSuccess(response: SearchClient.ResponseValue) {
+                        val searchResult: SearchResult = response.results[0]
+                        mNewSIView.showClientDetails(searchResult.resultId.toLong(),
+                                searchResult.resultName, externalId)
+                    }
+
+                    override fun onError(message: String) =
+                            mNewSIView.showFailureSearchingClient("VPA Not Found")
+
+                })
+    }
+
+    override fun createNewSI(toClientId: Long, amount: Double, recurrenceInterval: Int,
+                             validTill: String) {
+        mNewSIView.showLoadingView()
+
+        val validTillDateArray = validTill.split("-")
+        val validTillString =
+                "${validTillDateArray[0]} ${validTillDateArray[1]} ${validTillDateArray[2]}"
+
+        var validFrom: String =
+                SimpleDateFormat("dd-MM-yyyy", Locale.getDefault()).format(Date())
+        val validFromDateArray = validFrom.split("-")
+        validFrom = "${validFromDateArray[0]} ${validFromDateArray[1]} ${validFromDateArray[2]}"
+        val recurrenceOnDateMonth = "${validFromDateArray[0]} ${validFromDateArray[1]}"
+
+        mUseCaseHandler.execute(createStandingTransaction,
+                CreateStandingTransaction.RequestValues(validTillString, validFrom,
+                        recurrenceInterval, recurrenceOnDateMonth, preferencesHelper.clientId,
+                        toClientId, amount), object :
+                UseCaseCallback<CreateStandingTransaction.ResponseValue> {
+
+                    override fun onSuccess(response: CreateStandingTransaction.ResponseValue) =
+                        mNewSIView.showSuccess("Successful")
+
+                    override fun onError(message: String) =
+                            mNewSIView.showFailureCreatingNewSI(message)
+
+                })
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/presenter/StandingInstructionDetailsPresenter.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/presenter/StandingInstructionDetailsPresenter.kt
@@ -1,0 +1,86 @@
+package org.mifos.mobilewallet.mifospay.standinginstruction.presenter
+
+import org.mifos.mobilewallet.core.base.UseCase
+import org.mifos.mobilewallet.core.base.UseCaseHandler
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction
+import org.mifos.mobilewallet.core.domain.usecase.standinginstruction.FetchStandingInstruction
+import org.mifos.mobilewallet.core.domain.usecase.standinginstruction.DeleteStandingInstruction
+import org.mifos.mobilewallet.core.domain.usecase.standinginstruction.UpdateStandingInstruction
+import org.mifos.mobilewallet.mifospay.R
+import org.mifos.mobilewallet.mifospay.base.BaseView
+import org.mifos.mobilewallet.mifospay.standinginstruction.StandingInstructionContract
+import javax.inject.Inject
+
+/**
+ * Created by Devansh on 09/06/2020
+ */
+class StandingInstructionDetailsPresenter @Inject constructor(val mUseCaseHandler: UseCaseHandler) :
+        StandingInstructionContract.StandingInstructorDetailsPresenter{
+
+    @Inject
+    lateinit var fetchStandingInstruction: FetchStandingInstruction
+
+    @Inject
+    lateinit var updateStandingInstruction: UpdateStandingInstruction
+
+    @Inject
+    lateinit var deleteStandingInstruction: DeleteStandingInstruction
+
+    lateinit var mSIDetailsView: StandingInstructionContract.SIDetailsView
+
+    override fun attachView(baseView: BaseView<*>?) {
+        mSIDetailsView = baseView as  StandingInstructionContract.SIDetailsView
+        mSIDetailsView.setPresenter(this)
+    }
+
+    override fun fetchStandingInstructionDetails(standingInstructionId: Long) {
+        mSIDetailsView.showLoadingView()
+        mUseCaseHandler.execute(fetchStandingInstruction,
+                FetchStandingInstruction.RequestValues(standingInstructionId), object :
+                UseCase.UseCaseCallback<FetchStandingInstruction.ResponseValue> {
+
+            override fun onSuccess(response: FetchStandingInstruction.ResponseValue) {
+                mSIDetailsView.showSIDetails(response.standingInstruction)
+            }
+
+            override fun onError(message: String) {
+                mSIDetailsView.showStateView(R.drawable.ic_error_state, R.string.error_oops,
+                        R.string.error_fetching_si_details)
+            }
+        })
+    }
+
+    override fun deleteStandingInstruction(standingInstructionId: Long) {
+        mSIDetailsView.showLoadingView()
+        mUseCaseHandler.execute(deleteStandingInstruction,
+                DeleteStandingInstruction.RequestValues(standingInstructionId), object :
+                UseCase.UseCaseCallback<DeleteStandingInstruction.ResponseValue> {
+
+            override fun onSuccess(response: DeleteStandingInstruction.ResponseValue) {
+                mSIDetailsView.siDeletedSuccessfully()
+            }
+
+            override fun onError(message: String) {
+                mSIDetailsView.updateDeleteFailure()
+                mSIDetailsView.showToast("Error occurred, cannot delete")
+            }
+        })
+    }
+
+    override fun updateStandingInstruction(standingInstruction: StandingInstruction) {
+        mSIDetailsView.showLoadingView()
+        mUseCaseHandler.execute(updateStandingInstruction,
+                UpdateStandingInstruction.RequestValues(standingInstruction.id, standingInstruction)
+                , object : UseCase.UseCaseCallback<UpdateStandingInstruction.ResponseValue> {
+
+            override fun onSuccess(response: UpdateStandingInstruction.ResponseValue) {
+                mSIDetailsView.showSIDetails(standingInstruction)
+            }
+
+            override fun onError(message: String) {
+                mSIDetailsView.updateDeleteFailure()
+                mSIDetailsView.showToast("Error occurred, cannot update")
+            }
+        })
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/presenter/StandingInstructionsPresenter.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/presenter/StandingInstructionsPresenter.kt
@@ -1,0 +1,51 @@
+package org.mifos.mobilewallet.mifospay.standinginstruction.presenter
+
+import org.mifos.mobilewallet.core.base.UseCase.UseCaseCallback
+import org.mifos.mobilewallet.core.base.UseCaseHandler
+import org.mifos.mobilewallet.core.domain.usecase.standinginstruction.GetAllStandingInstructions
+import org.mifos.mobilewallet.mifospay.R
+import org.mifos.mobilewallet.mifospay.base.BaseView
+import org.mifos.mobilewallet.mifospay.data.local.LocalRepository
+import org.mifos.mobilewallet.mifospay.standinginstruction.StandingInstructionContract
+import javax.inject.Inject
+
+/**
+ * Created by Devansh on 08/06/2020
+ */
+class StandingInstructionsPresenter @Inject constructor (val mUseCaseHandler: UseCaseHandler,
+                                                         val localRepository: LocalRepository)
+    : StandingInstructionContract.StandingInstructionsPresenter {
+
+    lateinit var mSIListView: StandingInstructionContract.SIListView
+
+    @Inject
+    lateinit var getAllStandingInstructions: GetAllStandingInstructions
+
+    override fun attachView(baseView: BaseView<*>?) {
+        mSIListView = baseView as StandingInstructionContract.SIListView
+        mSIListView.setPresenter(this)
+    }
+
+    override fun getAllSI() {
+        val client = localRepository.clientDetails
+        mSIListView.showLoadingView()
+        mUseCaseHandler.execute(getAllStandingInstructions,
+                GetAllStandingInstructions.RequestValues(client.clientId), object :
+                UseCaseCallback<GetAllStandingInstructions.ResponseValue> {
+
+            override fun onSuccess(response: GetAllStandingInstructions.ResponseValue) {
+                if (response.standingInstructionsList.isEmpty()) {
+                    mSIListView.showStateView(R.drawable.ic_empty_state, R.string.error_oops,
+                            R.string.empty_standing_instructions)
+                } else {
+                    mSIListView.showStandingInstructions(response.standingInstructionsList)
+                }
+            }
+
+            override fun onError(message: String) {
+                mSIListView.showStateView(R.drawable.ic_error_state, R.string.error_oops,
+                        R.string.error_fetching_si_list)
+            }
+        })
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/NewSIActivity.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/NewSIActivity.kt
@@ -1,0 +1,141 @@
+package org.mifos.mobilewallet.mifospay.standinginstruction.ui
+
+import android.app.DatePickerDialog
+import android.app.DatePickerDialog.OnDateSetListener
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import butterknife.ButterKnife
+import butterknife.OnClick
+import kotlinx.android.synthetic.main.activity_new_si.*
+import org.mifos.mobilewallet.mifospay.R
+import org.mifos.mobilewallet.mifospay.base.BaseActivity
+import org.mifos.mobilewallet.mifospay.standinginstruction.StandingInstructionContract
+import org.mifos.mobilewallet.mifospay.standinginstruction.presenter.NewSIPresenter
+import org.mifos.mobilewallet.mifospay.utils.Constants
+import org.mifos.mobilewallet.mifospay.utils.Utils
+import java.util.*
+import javax.inject.Inject
+import kotlin.properties.Delegates
+
+
+class NewSIActivity : BaseActivity(), StandingInstructionContract.NewSIView {
+
+    @Inject
+    lateinit var mPresenter: NewSIPresenter
+    private lateinit var mNewSIPresenter: StandingInstructionContract.NewSIPresenter
+
+    private var clientId by Delegates.notNull<Long>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_new_si)
+        activityComponent.inject(this)
+        ButterKnife.bind(this)
+        setToolbarTitle(getString(R.string.tile_si_activity))
+        showColoredBackButton(Constants.BLACK_BACK_BUTTON)
+        mPresenter.attachView(this)
+    }
+
+    override fun setPresenter(presenter: StandingInstructionContract.NewSIPresenter) {
+        this.mNewSIPresenter = presenter
+    }
+
+    @OnClick(R.id.btn_valid_till)
+    fun pickToDate() {
+        val calendar: Calendar = Calendar.getInstance()
+        val day: Int = calendar.get(Calendar.DAY_OF_MONTH)
+        val month: Int = calendar.get(Calendar.MONTH)
+        val year: Int = calendar.get(Calendar.YEAR)
+        val picker = DatePickerDialog(this,
+                OnDateSetListener {
+                    view, year, monthOfYear, dayOfMonth ->
+                    btn_valid_till.text = "${dayOfMonth.toString()}-${(monthOfYear + 1)}-$year"
+                }, year, month, day)
+        picker.show()
+    }
+
+    @OnClick(R.id.btn_create_si)
+    fun createSI() {
+        if (et_si_amount.text.toString() == "") {
+            showToast(getString(R.string.enter_amount))
+            return
+        } else if (et_si_amount.text.toString().toInt() <= 0) {
+            showToast(getString(R.string.enter_valid_amount))
+            return
+        }
+        if (et_si_vpa.text.toString() == "") {
+            showToast(getString(R.string.enter_VPA))
+            return
+        }
+        if (et_si_interval.text.toString() == "") {
+            showToast(getString(R.string.enter_recurrence_interval))
+            return
+        } else if (et_si_interval.text.toString().toInt() <= 1) {
+            showToast(getString(R.string.invalid_recurrence_interval))
+            return
+        }
+        if (btn_valid_till.text == Constants.SELECT_DATE) {
+            showToast(getString(R.string.select_till_date))
+            return
+        }
+        Utils.hideSoftKeyboard(this)
+        mNewSIPresenter.fetchClient(et_si_vpa.text.toString())
+    }
+
+    override fun showClientDetails(clientId: Long, name: String, externalId: String) {
+        this.clientId = clientId
+        tv_client_name.text = name
+        tv_client_vpa.text = externalId
+        tv_amount.text = resources.getString(R.string.currency_amount,
+                Constants.RUPEE, et_si_amount.text)
+
+        ll_create_si.visibility = View.GONE
+        ll_confirm_transfer.visibility = View.VISIBLE
+        ll_confirm_cancel.visibility = View.VISIBLE
+        progressBar.visibility = View.GONE
+    }
+
+    @OnClick(R.id.btn_confirm)
+    fun createNewStandingInstruction() {
+        ll_confirm_cancel.visibility = View.GONE
+        progressBar.visibility = View.VISIBLE
+        mNewSIPresenter.createNewSI(clientId, (et_si_amount.text.toString()).toDouble(),
+                et_si_interval.text.toString().toInt(), btn_valid_till.text.toString())
+    }
+
+    @OnClick(R.id.btn_cancel)
+    fun cancelNewStandingInstruction() {
+        ll_confirm_transfer.visibility = View.GONE
+        ll_create_si.visibility = View.VISIBLE
+    }
+
+    override fun showLoadingView() {
+        ll_create_si.visibility = View.GONE
+        ll_confirm_cancel.visibility = View.GONE
+        ll_confirm_transfer.visibility = View.GONE
+        progressBar.visibility = View.VISIBLE
+    }
+
+    override fun showFailureSearchingClient(message: String) {
+        progressBar.visibility = View.GONE
+        ll_create_si.visibility = View.VISIBLE
+        showToast(message)
+    }
+
+    private fun showToast(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
+    override fun showSuccess(message: String) {
+        showToast(message)
+    }
+
+    override fun showFailureCreatingNewSI(message: String) {
+        ll_confirm_transfer.visibility = View.VISIBLE
+        progressBar.visibility = View.GONE
+        ll_confirm_cancel.visibility = View.VISIBLE
+        showToast(message)
+    }
+
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIDetailsActivity.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIDetailsActivity.kt
@@ -1,0 +1,279 @@
+package org.mifos.mobilewallet.mifospay.standinginstruction.ui
+
+import android.app.DatePickerDialog
+import android.content.res.Resources
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.widget.Toast
+import butterknife.ButterKnife
+import butterknife.OnTextChanged
+import kotlinx.android.synthetic.main.activity_si_details.*
+import kotlinx.android.synthetic.main.placeholder_state.*
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction
+import org.mifos.mobilewallet.mifospay.R
+import org.mifos.mobilewallet.mifospay.base.BaseActivity
+import org.mifos.mobilewallet.mifospay.standinginstruction.StandingInstructionContract
+import org.mifos.mobilewallet.mifospay.standinginstruction.presenter.StandingInstructionDetailsPresenter
+import org.mifos.mobilewallet.mifospay.utils.Constants
+import org.mifos.mobilewallet.mifospay.utils.DialogBox
+import org.mifos.mobilewallet.mifospay.utils.Utils
+import java.util.*
+import javax.inject.Inject
+
+class SIDetailsActivity : BaseActivity(), StandingInstructionContract.SIDetailsView {
+
+    // using 0 as default values
+    private var standingInstructionId: Long = 0
+
+    private lateinit var standingInstruction: StandingInstruction
+    private lateinit var res: Resources
+
+    /**
+     * This variable is used to overload fab to both save unsaved changes and to enter into edit
+     * details screen. On start, its set to false to allow user to go to edit screen
+     */
+    private var doSave: Boolean = false
+
+    @Inject
+    lateinit var mPresenter: StandingInstructionDetailsPresenter
+    private lateinit var mStandingInstructionPresenter:
+            StandingInstructionContract.StandingInstructorDetailsPresenter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_si_details)
+        activityComponent.inject(this)
+        ButterKnife.bind(this)
+        setToolbarTitle(getString(R.string.details))
+        showColoredBackButton(Constants.BLACK_BACK_BUTTON)
+        mPresenter.attachView(this)
+        res = resources
+
+        intent?.let {
+            this.standingInstructionId = it.getLongExtra(Constants.SI_ID, 0)
+            mStandingInstructionPresenter.fetchStandingInstructionDetails(standingInstructionId)
+        }
+        setUpUI()
+    }
+
+    private fun setUpUI() {
+        tv_edit_pick.setOnClickListener {
+            val calendar: Calendar = Calendar.getInstance()
+            val day: Int = calendar.get(Calendar.DAY_OF_MONTH)
+            val month: Int = calendar.get(Calendar.MONTH)
+            val year: Int = calendar.get(Calendar.YEAR)
+            val picker = DatePickerDialog(this,
+                    DatePickerDialog.OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
+                        tv_valid_till.text = "$dayOfMonth-${(monthOfYear + 1)}-$year"
+                    }, year, month, day)
+            picker.show()
+        }
+
+        fab.setOnClickListener {
+            fabOnClickAction()
+        }
+    }
+
+    override fun setPresenter(presenter:
+                              StandingInstructionContract.StandingInstructorDetailsPresenter) {
+        this.mStandingInstructionPresenter = presenter
+    }
+
+    override fun showLoadingView() {
+        layout_si_details.visibility = View.GONE
+        inc_state_view.visibility = View.GONE
+        progressBar.visibility = View.VISIBLE
+    }
+
+    /**
+     * This function is used to both save unsaved details and to allow user to enter edit screen.
+     */
+    private fun fabOnClickAction() {
+        if (doSave) {
+            if (checkInput()) {
+                Utils.hideSoftKeyboard(this)
+
+                this.standingInstruction.amount = et_si_edit_amount.text.toString().toDouble()
+                this.standingInstruction.recurrenceInterval =
+                        et_si_edit_interval.text.toString().toInt()
+                val validTillArray = tv_valid_till.text.split("-")
+                this.standingInstruction.validTill = validTillArray.map { it.toInt() }
+
+                // passing the updated standing instruction
+                mStandingInstructionPresenter.updateStandingInstruction(this.standingInstruction)
+            }
+        } else {
+            doSave = true
+            fab.hide()
+            fab.setImageDrawable(res.getDrawable(R.drawable.ic_save))
+
+            tv_si_amount.visibility = View.GONE
+            til_si_edit_amount.visibility = View.VISIBLE
+
+            tv_edit_pick.visibility = View.VISIBLE
+
+            tv_recurrence_interval.visibility = View.GONE
+            til_si_edit_interval.visibility = View.VISIBLE
+        }
+    }
+
+    /**
+     * Checks the input from the user and returns false if the input is invalid otherwise true
+     */
+    private fun checkInput(): Boolean {
+        if (et_si_edit_amount.text.toString() == "") {
+            showToast(getString(R.string.enter_amount))
+            return false
+        } else if (et_si_edit_amount.text.toString().toDouble() <= 0) {
+            showToast(getString(R.string.enter_valid_amount))
+            return false
+        }
+        if (et_si_edit_interval.text.toString() == "") {
+            showToast(getString(R.string.enter_recurrence_interval))
+            return false
+        } else if (et_si_edit_interval.text.toString().toInt() <= 1) {
+            showToast(getString(R.string.invalid_recurrence_interval))
+            return false
+        }
+        return true
+    }
+
+    override fun showSIDetails(standingInstruction: StandingInstruction) {
+        this.standingInstruction = standingInstruction
+        hideProgressBar()
+        layout_si_details.visibility = View.VISIBLE
+
+        // setting up the layout
+        tv_si_name.text = standingInstruction.name
+        tv_si_id.text = standingInstruction.id.toString()
+        /**
+         * Using hardcoded Currency as response doesn't return the currency
+         */
+        tv_si_amount.text = res.getString(R.string.currency_amount, Constants.RUPEE,
+                standingInstruction.amount.toString())
+
+        tv_valid_from.text = res.getString(R.string.date_formatted,
+                standingInstruction.validFrom[2].toString(),
+                standingInstruction.validFrom[1].toString(),
+                standingInstruction.validFrom[0].toString())
+        tv_valid_till.text = res.getString(R.string.date_formatted,
+                standingInstruction.validTill?.get(2).toString(),
+                standingInstruction.validTill?.get(1).toString(),
+                standingInstruction.validTill?.get(0).toString())
+
+        tv_si_from_name.text = res.getString(R.string.name_client_name,
+                standingInstruction.fromClient.displayName)
+        tv_si_from_number.text = res.getString(R.string.number_account_number,
+                standingInstruction.fromAccount.accountNo)
+        tv_si_to_name.text = res.getString(R.string.name_client_name,
+                standingInstruction.toClient.displayName)
+        tv_si_to_number.text = res.getString(R.string.number_account_number,
+                standingInstruction.toAccount.accountNo)
+
+        tv_si_status.text = standingInstruction.status.value
+        tv_recurrence_interval.text = standingInstruction.recurrenceInterval.toString()
+
+        // setting up TextInputLayouts
+        /**
+         * Using hardcoded Currency as response doesn't return the currency
+         */
+        til_si_edit_amount.hint = "${Constants.RUPEE} ${standingInstruction.amount}"
+        til_si_edit_interval.hint = standingInstruction.recurrenceInterval.toString()
+        et_si_edit_amount.setText(standingInstruction.amount.toString())
+        et_si_edit_interval.setText(standingInstruction.recurrenceInterval.toString())
+    }
+
+    @OnTextChanged(R.id.et_si_edit_amount, R.id.et_si_edit_interval, R.id.tv_valid_till)
+    fun onDetailsChanged() {
+        if (isDataSaveNecessary()) {
+            fab.show()
+        } else if (!doSave) {
+            // for initial state
+            fab.show()
+        } else {
+            fab.hide()
+        }
+    }
+
+    private fun isDataSaveNecessary(): Boolean {
+        val originalValidTillDate = "${standingInstruction.validTill?.get(2)}-" +
+                "${standingInstruction.validTill?.get(1)}-${standingInstruction.validTill?.get(0)}"
+
+        return !((this.standingInstruction.amount.toString() == et_si_edit_amount.text.toString())
+                && (this.standingInstruction.recurrenceInterval.toString()
+                == et_si_edit_interval.text.toString())
+                && (originalValidTillDate == tv_valid_till.text.toString()))
+    }
+
+    override fun showStateView(drawable: Int, errorTitle: Int, errorMessage: Int) {
+        hideProgressBar()
+        layout_si_details.visibility = View.GONE
+        inc_state_view.visibility = View.VISIBLE
+
+        iv_empty_no_transaction_history
+                    .setImageDrawable(res.getDrawable(drawable))
+        tv_empty_no_transaction_history_title.text = res.getString(errorTitle)
+        tv_empty_no_transaction_history_subtitle.text = res.getString(errorMessage)
+    }
+
+    override fun siDeletedSuccessfully() {
+        showToast(getString(R.string.deleted_successfully))
+        finish()
+    }
+
+    override fun updateDeleteFailure() {
+        hideProgressBar()
+        layout_si_details.visibility = View.VISIBLE
+    }
+
+    private fun hideProgressBar() {
+        progressBar.visibility = View.GONE
+    }
+
+    override fun showToast(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.menu_si_details, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.item_delete ->
+                /**
+                 * perform delete action only when details have been successfully fetched
+                 */
+                if (this.standingInstructionId != 0L) {
+                    mStandingInstructionPresenter.deleteStandingInstruction(
+                            this.standingInstructionId)
+                }
+            else -> return super.onOptionsItemSelected(item)
+        }
+        return true
+    }
+
+    override fun onBackPressed() {
+        if (isDataSaveNecessary()) {
+            showDiscardChangesDialog()
+        } else {
+            super.onBackPressed()
+        }
+    }
+
+    private fun showDiscardChangesDialog() {
+        val dialogBox = DialogBox()
+        dialogBox.setOnPositiveListener { dialog, which ->
+            dialog.dismiss()
+            finish()
+        }
+        dialogBox.setOnNegativeListener { dialog, which ->
+            dialog.dismiss()
+        }
+        dialogBox.show(this, R.string.discard_changes_and_exit,
+                R.string.discard_and_exit, R.string.accept, R.string.cancel)
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIFragment.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIFragment.kt
@@ -1,0 +1,118 @@
+package org.mifos.mobilewallet.mifospay.standinginstruction.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.support.v7.widget.LinearLayoutManager
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.fragment_si.*
+import kotlinx.android.synthetic.main.fragment_si.inc_state_view
+import kotlinx.android.synthetic.main.fragment_si.progressBar
+import kotlinx.android.synthetic.main.placeholder_state.*
+import org.mifos.mobilewallet.core.data.fineract.entity.standinginstruction.StandingInstruction
+import org.mifos.mobilewallet.mifospay.R
+import org.mifos.mobilewallet.mifospay.base.BaseActivity
+import org.mifos.mobilewallet.mifospay.base.BaseFragment
+import org.mifos.mobilewallet.mifospay.standinginstruction.StandingInstructionContract
+import org.mifos.mobilewallet.mifospay.standinginstruction.adapter.StandingInstructionAdapter
+import org.mifos.mobilewallet.mifospay.standinginstruction.presenter.StandingInstructionsPresenter
+import org.mifos.mobilewallet.mifospay.utils.Constants
+import org.mifos.mobilewallet.mifospay.utils.RecyclerItemClickListener
+import javax.inject.Inject
+
+
+class SIFragment : BaseFragment(), StandingInstructionContract.SIListView {
+
+    @Inject
+    lateinit var mPresenter: StandingInstructionsPresenter
+    private lateinit var mStandingInstructionPresenter:
+            StandingInstructionContract.StandingInstructionsPresenter
+
+    lateinit var mSIAdapter: StandingInstructionAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (activity as BaseActivity).activityComponent.inject(this)
+        mSIAdapter = StandingInstructionAdapter(activity as BaseActivity)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_si, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        mPresenter.attachView(this)
+        mStandingInstructionPresenter.getAllSI()
+        setUpUI()
+    }
+
+    override fun setPresenter(presenter:
+                              StandingInstructionContract.StandingInstructionsPresenter) {
+        this.mStandingInstructionPresenter = presenter
+    }
+
+    private fun setUpUI() {
+        fab_new_si.setOnClickListener {
+            val i = Intent(activity, NewSIActivity::class.java)
+            startActivity(i)
+        }
+        setUpRecyclerView()
+        setupSwipeRefreshLayout()
+    }
+
+    private fun setUpRecyclerView() {
+        rv_si.layoutManager = LinearLayoutManager(context)
+        rv_si.adapter = mSIAdapter
+        rv_si.addOnItemTouchListener(RecyclerItemClickListener(context,
+                object : RecyclerItemClickListener.OnItemClickListener {
+                    override fun onItemLongPress(childView: View?, position: Int) {
+
+                    }
+
+                    override fun onItemClick(childView: View, position: Int) {
+                        val intent = Intent(activity, SIDetailsActivity::class.java)
+                        val standingInstructionId =
+                                mSIAdapter.getStandingInstruction(position)?.id
+                        standingInstructionId?. let {
+                            intent.putExtra(Constants.SI_ID, standingInstructionId)
+                            startActivity(intent)
+                        }
+                    }
+                }))
+    }
+
+    private fun setupSwipeRefreshLayout() {
+        setSwipeEnabled(true)
+        swipeRefreshLayout.setOnRefreshListener {
+            swipeRefreshLayout.isRefreshing = false
+            mStandingInstructionPresenter.getAllSI()
+        }
+    }
+
+    override fun showLoadingView() {
+        inc_state_view.visibility = View.GONE
+        rv_si.visibility = View.GONE
+        progressBar.visibility = View.VISIBLE
+    }
+
+    override fun showStandingInstructions(standingInstructionList: List<StandingInstruction>) {
+        progressBar.visibility = View.GONE
+        rv_si.visibility = View.VISIBLE
+        mSIAdapter.setData(standingInstructionList)
+    }
+
+    override fun showStateView(drawable: Int, errorTitle: Int, errorMessage: Int) {
+        progressBar.visibility = View.GONE
+        rv_si.visibility = View.GONE
+        inc_state_view.visibility = View.VISIBLE
+
+        // setting up state view elements
+        val res = resources
+        iv_empty_no_transaction_history
+                .setImageDrawable(res.getDrawable(drawable))
+        tv_empty_no_transaction_history_title.text = res.getString(errorTitle)
+        tv_empty_no_transaction_history_subtitle.text = res.getString(errorMessage)
+    }
+}

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
@@ -195,4 +195,7 @@ public class Constants {
 
     public static final String CURRENT_PASSCODE = "current passcode";
     public static final String UPDATE_PASSCODE = "update passcode";
+    public static final String SELECT_DATE = "SELECT DATE";
+
+    public static final String SI_ID = "standing_instruction_id";
 }

--- a/mifospay/src/main/res/drawable/ic_add_white.xml
+++ b/mifospay/src/main/res/drawable/ic_add_white.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFF"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/mifospay/src/main/res/layout/activity_new_si.xml
+++ b/mifospay/src/main/res/layout/activity_new_si.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include layout="@layout/toolbar"/>
+
+    <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:id="@+id/ll_create_si"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <android.support.design.widget.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="80dp"
+                android:id="@+id/til_si_amount"
+                android:layout_marginLeft="@dimen/value_20dp"
+                android:layout_marginRight="@dimen/value_20dp"
+                android:layout_marginTop="@dimen/value_20dp"
+                android:layout_marginBottom="@dimen/value_10dp"
+                android:padding="@dimen/value_10dp"
+                android:textColorHint="@android:color/black"
+                app:hintTextAppearance="@style/TextAppearance.App.TextInputLayout">
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/et_si_amount"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:hint="@string/amount"
+                    android:inputType="number"
+                    android:textSize="@dimen/value_15sp"
+                    android:theme="@style/Theme.AppCompat.Light" />
+
+            </android.support.design.widget.TextInputLayout>
+
+            <android.support.design.widget.TextInputLayout
+                android:id="@+id/til_si_vpa"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="80dp"
+                android:layout_marginLeft="@dimen/value_20dp"
+                android:layout_marginRight="@dimen/value_20dp"
+                android:layout_marginTop="@dimen/value_10dp"
+                android:layout_marginBottom="@dimen/value_10dp"
+                android:padding="@dimen/value_10dp"
+                android:textColorHint="@android:color/black"
+                app:hintTextAppearance="@style/TextAppearance.App.TextInputLayout">
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/et_si_vpa"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:hint="@string/virtual_payment_address"
+                    android:singleLine="true"
+                    android:textSize="@dimen/value_15sp"
+                    android:theme="@style/Theme.AppCompat.Light" />
+            </android.support.design.widget.TextInputLayout>
+
+            <android.support.design.widget.TextInputLayout
+                android:id="@+id/til_si_interval"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="80dp"
+                android:layout_marginLeft="@dimen/value_20dp"
+                android:layout_marginRight="@dimen/value_20dp"
+                android:layout_marginTop="@dimen/value_10dp"
+                android:layout_marginBottom="@dimen/value_10dp"
+                android:padding="@dimen/value_10dp"
+                android:textColorHint="@android:color/black"
+                app:hintTextAppearance="@style/TextAppearance.App.TextInputLayout">
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/et_si_interval"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:hint="Recurrence Interval (in months)"
+                    android:singleLine="true"
+                    android:inputType="number"
+                    android:textSize="@dimen/value_15sp"
+                    android:theme="@style/Theme.AppCompat.Light" />
+            </android.support.design.widget.TextInputLayout>
+
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/valid_till"
+                android:layout_marginBottom="@dimen/value_10dp"
+                android:textColor="@color/black"
+                android:textSize="@dimen/value_16sp"
+                android:layout_gravity="center" />
+            <Button
+                android:id="@+id/btn_valid_till"
+                android:layout_width="160dp"
+                android:layout_height="@dimen/value_50dp"
+                android:text="SELECT DATE"
+                android:layout_gravity="center"
+                android:layout_marginBottom="@dimen/value_20dp"
+                android:textColor="@color/white" />
+            <Button
+                android:id="@+id/btn_create_si"
+                android:layout_width="260dp"
+                android:layout_height="@dimen/value_50dp"
+                android:text="@string/submit"
+                android:layout_gravity="center"
+                android:textColor="@color/white" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/ll_confirm_transfer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"
+            android:padding="@dimen/value_20dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/sending_to"
+                android:textColor="@color/primaryDarkBlue"
+                android:textSize="@dimen/value_15sp"/>
+
+            <TextView
+                android:id="@+id/tv_client_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/value_10dp"
+                android:textColor="@android:color/black"
+                android:textSize="@dimen/value_20sp"/>
+
+            <TextView
+                android:id="@+id/tv_client_vpa"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/value_5dp"
+                android:textSize="@dimen/value_18sp"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/value_20dp"
+                android:text="@string/amount"
+                android:textColor="@color/primaryDarkBlue"
+                android:textSize="@dimen/value_15sp"/>
+
+            <TextView
+                android:id="@+id/tv_amount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/value_10dp"
+                android:textColor="@android:color/black"
+                android:textSize="@dimen/value_20sp"/>
+
+            <LinearLayout
+                android:id="@+id/ll_confirm_cancel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="@dimen/value_10dp"
+                android:layout_marginTop="@dimen/value_30dp"
+                android:gravity="right"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/btn_cancel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@color/grey_900"
+                    android:text="@string/cancel"
+                    android:textColor="@android:color/white"/>
+
+                <Button
+                    android:id="@+id/btn_confirm"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="right"
+                    android:layout_marginLeft="@dimen/value_30dp"
+                    android:background="@color/primaryDarkBlue"
+                    android:text="@string/confirm"
+                    android:textColor="@android:color/white"/>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:visibility="gone" />
+
+    </android.support.constraint.ConstraintLayout>
+
+</LinearLayout>

--- a/mifospay/src/main/res/layout/activity_si_details.xml
+++ b/mifospay/src/main/res/layout/activity_si_details.xml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".standinginstruction.ui.SIDetailsActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <include layout="@layout/toolbar"/>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <android.support.constraint.ConstraintLayout
+                android:id="@+id/layout_si_details"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:id="@+id/tv_si_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/marginItemsInSectionMedium"
+                    android:textColor="@color/black"
+                    android:textSize="40sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/value_40dp"
+                    android:layout_marginStart="@dimen/value_20dp"
+                    android:layout_marginEnd="@dimen/value_20dp"
+                    android:layout_marginLeft="@dimen/value_20dp"
+                    app:layout_constraintTop_toBottomOf="@id/tv_si_name"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/gray_dark"
+                        android:textSize="@dimen/value_16sp"
+                        android:text="Standing Instruction ID:"/>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/tv_si_id"
+                        android:textColor="@color/colorAccent"
+                        android:textSize="@dimen/value_16sp"
+                        android:layout_marginBottom="@dimen/marginItemsInSectionMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/gray_dark"
+                        android:textSize="@dimen/value_16sp"
+                        android:text="@string/amount_header"/>
+                    <LinearLayout
+                        android:orientation="horizontal"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/marginItemsInSectionMedium">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/tv_si_amount"
+                            android:textStyle="bold"
+                            android:textColor="@color/black"
+                            android:textSize="@dimen/value_16sp" />
+
+                        <android.support.design.widget.TextInputLayout
+                            android:id="@+id/til_si_edit_amount"
+                            android:visibility="gone"
+                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                            android:layout_width="@dimen/value_100dp"
+                            android:layout_height="wrap_content"
+                            android:textColorHint="@android:color/black"
+                            app:hintTextAppearance="@style/TextAppearance.App.TextInputLayout">
+
+                            <android.support.design.widget.TextInputEditText
+                                android:id="@+id/et_si_edit_amount"
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent"
+                                android:inputType="numberDecimal"
+                                android:textSize="@dimen/value_15sp"
+                                android:theme="@style/Theme.AppCompat.Light" />
+
+                        </android.support.design.widget.TextInputLayout>
+
+                    </LinearLayout>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/gray_dark"
+                        android:textSize="@dimen/value_16sp"
+                        android:text="Valid From:"/>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/tv_valid_from"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/value_16sp"
+                        android:layout_marginBottom="@dimen/marginItemsInSectionMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/gray_dark"
+                        android:textSize="@dimen/value_16sp"
+                        android:text="Valid Till:"/>
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:layout_marginBottom="@dimen/marginItemsInSectionMedium">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/tv_valid_till"
+                            android:textColor="@color/black"
+                            android:textSize="@dimen/value_16sp"
+                            android:layout_marginRight="@dimen/value_20dp"/>
+
+                        <TextView
+                            android:id="@+id/tv_edit_pick"
+                            android:visibility="gone"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/pick_the_date"
+                            android:textColor="@color/primaryBlue"
+                            android:textSize="@dimen/value_15sp"/>
+
+                    </LinearLayout>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/gray_dark"
+                        android:textSize="@dimen/value_16sp"
+                        android:text="@string/to"/>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/tv_si_to_name"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/value_16sp" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/tv_si_to_number"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/value_16sp"
+                        android:layout_marginBottom="@dimen/marginItemsInSectionMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/gray_dark"
+                        android:textSize="@dimen/value_16sp"
+                        android:text="@string/from"/>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/tv_si_from_name"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/value_16sp" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/tv_si_from_number"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/value_16sp"
+                        android:layout_marginBottom="@dimen/marginItemsInSectionMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/gray_dark"
+                        android:textSize="@dimen/value_16sp"
+                        android:text="Recurrence Interval in Months:"/>
+                    <LinearLayout
+                        android:orientation="horizontal"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/marginItemsInSectionMedium">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/tv_recurrence_interval"
+                            android:textColor="@color/black"
+                            android:textSize="@dimen/value_16sp" />
+
+                        <android.support.design.widget.TextInputLayout
+                            android:id="@+id/til_si_edit_interval"
+                            android:visibility="gone"
+                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                            android:layout_width="@dimen/value_100dp"
+                            android:layout_height="wrap_content"
+                            android:textColorHint="@android:color/black"
+                            app:hintTextAppearance="@style/TextAppearance.App.TextInputLayout">
+
+                            <android.support.design.widget.TextInputEditText
+                                android:id="@+id/et_si_edit_interval"
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent"
+                                android:inputType="number"
+                                android:textSize="@dimen/value_15sp"
+                                android:theme="@style/Theme.AppCompat.Light" />
+
+                        </android.support.design.widget.TextInputLayout>
+
+                    </LinearLayout>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/gray_dark"
+                        android:textSize="@dimen/value_16sp"
+                        android:text="Status:"/>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/tv_si_status"
+                        android:textColor="@color/primaryBlue"
+                        android:textSize="@dimen/value_16sp"
+                        android:layout_marginBottom="@dimen/marginItemsInSectionMedium" />
+
+                </LinearLayout>
+
+            </android.support.constraint.ConstraintLayout>
+
+        </ScrollView>
+
+    </LinearLayout>
+
+    <ProgressBar
+        android:visibility="gone"
+        android:id="@+id/progressBar"
+        style="@style/Widget.AppCompat.ProgressBar"
+        android:layout_gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <!-- used to show error screen-->
+    <include
+        android:visibility="gone"
+        android:id="@+id/inc_state_view"
+        layout="@layout/placeholder_state"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="@dimen/marginItemsInSectionLarge" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fab"
+        style="@style/Widget.MaterialComponents.FloatingActionButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/colorAccentBlack"
+        app:srcCompat="@drawable/ic_edit"
+        android:tint="@color/colorPrimary"
+        app:backgroundTint="@color/colorAccentBlack"
+        app:fabSize="normal"
+        android:layout_margin="@dimen/value_20dp"
+        android:layout_gravity="bottom|right"/>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/mifospay/src/main/res/layout/fragment_si.xml
+++ b/mifospay/src/main/res/layout/fragment_si.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:visibility="gone"
+        android:id="@+id/progressBar"
+        style="@style/Widget.AppCompat.ProgressBar"
+        android:layout_gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/rv_si"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="vertical" />
+
+    <include
+        android:visibility="gone"
+        android:id="@+id/inc_state_view"
+        layout="@layout/placeholder_state"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="@dimen/marginItemsInSectionLarge" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/fab_new_si"
+        android:layout_gravity="bottom|right"
+        android:layout_margin="20dp"
+        app:srcCompat="@drawable/ic_add_white"/>
+
+    <include
+        android:visibility="gone"
+        android:id="@+id/inc_state_view"
+        layout="@layout/placeholder_state"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="@dimen/marginItemsInSectionLarge" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/mifospay/src/main/res/layout/item_si.xml
+++ b/mifospay/src/main/res/layout/item_si.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <View
+        android:id="@+id/divider3"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginTop="8dp"
+        android:background="?android:attr/listDivider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_valid_till_date" />
+
+    <TextView
+        android:id="@+id/tv_from_client_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/value_10dp"
+        android:textColor="@color/colorTextPrimary"
+        android:textSize="@dimen/textBody1"
+        android:text="dadas"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_to_client_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/value_20dp"
+        android:layout_marginStart="@dimen/value_10dp"
+        android:textColor="@color/colorTextPrimary"
+        android:text="dadsdasdasd"
+        android:textSize="@dimen/textBody1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_from_client_name" />
+
+    <TextView
+        android:id="@+id/tv_valid_till_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textColor="@color/colorTextSecondary"
+        app:layout_constraintStart_toStartOf="@+id/tv_to_client_name"
+        app:layout_constraintTop_toBottomOf="@+id/tv_to_client_name" />
+
+    <TextView
+        android:id="@+id/tv_amount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="@dimen/marginItemsInSectionSmall"
+        android:layout_marginRight="@dimen/marginItemsInSectionSmall"
+        android:layout_marginBottom="8dp"
+        android:textSize="@dimen/value_16sp"
+        android:textColor="@color/colorAccent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/mifospay/src/main/res/menu/menu_si_details.xml
+++ b/mifospay/src/main/res/menu/menu_si_details.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".home.ui.MainActivity">
+
+    <item
+        android:id="@+id/item_delete"
+        android:title="@string/delete_standing_instruction"/>
+
+</menu>

--- a/mifospay/src/main/res/values/colors.xml
+++ b/mifospay/src/main/res/values/colors.xml
@@ -38,12 +38,12 @@
 
     <color name="colorBottomViewNotFocusedIcon">@color/colorAccentBlue50</color>
 
-
-
-
+    <color name="colorDebit">#F10606</color>
+    <color name="colorCredit">#009688</color>
 
 
     <!-- OLD COLORS ARE TEMPORARY HERE UNTIL ALL OF THE LAYOUT WON'T BE REDESIGNED TO AVOID CRASHES/BUGS/CONFLICTS -->
+
 
     <color name="primaryBlue">#3F51B5</color>
     <color name="primaryDarkBlue">#303F9F</color>

--- a/mifospay/src/main/res/values/dimens.xml
+++ b/mifospay/src/main/res/values/dimens.xml
@@ -61,5 +61,7 @@
     <dimen name="marginItemsInSectionExtraSmall">8dp</dimen>
     <dimen name="value_120dp">120dp</dimen>
     <dimen name="value_250dp">250dp</dimen>
+    <dimen name="value_60dp">60dp</dimen>
+    <dimen name="value_24sp">24sp</dimen>
 
 </resources>

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -272,5 +272,34 @@
     <string name="no_bank_account">No bank found</string>
     <string name="error_specific_transactions">Couldn\'t fetch Specific transactions. Please, try again.</string>
     <string name="fetching_history">Fetching History...</string>
+    <string name="tile_si_activity">Create Standing Instruction</string>
+    <string name="standing_instruction">SI</string>
+    <string name="valid_till">Valid till :</string>
+    <string name="details">Details</string>
+    <string name="enter_valid_amount">Please enter a valid amount</string>
+    <string name="invalid_recurrence_interval">Interval cannot be smaller than 1 Month</string>
+    <string name="enter_recurrence_interval">Please enter the interval</string>
+    <string name="error_fetching_si_details">Couldn\'t fetch Standing Instruction details. Please, try again.</string>
+    <string name="error_fetching_si_list">Couldn\'t fetch Standing Instructions. Please, try again.</string>
+    <string name="discard_and_exit">This will discard all unsaved changes</string>
+    <string name="interval_cannot_smaller_than_1_month">Interval cannot be smaller than 1 Month</string>
+    <string name="delete_standing_instruction">Delete Standing Instruction</string>
+    <string name="pick_the_date"><u>pick the date</u></string>
+    <string name="empty_standing_instructions">No standing instructions to show</string>
+    <string name="select_till_date">Kindly select Till Date</string>
+    <string name="enter_VPA">Please enter the VPA</string>
+    <string name="amount_header">Amount:</string>
+    <string name="deleted_successfully">Deleted Successfully</string>
+
+    <!-- dynamically formatted strings-->
+    <string name="name_client_name">Name: %1$s</string>
+    <string name="number_account_number">Number: %1$s</string>
+    <string name="currency_amount">%1$s %2$s</string>
+    <string name="date_formatted">%1$s-%2$s-%3$s</string>
+    <string name="from_client_name">From: %1$s</string>
+    <string name="to_client_name">To: %1$s</string>
+    <string name="valid_till_date">Valid Till: %1$s</string>
+
+    <string name="title_activity_new_si">NewSIActivity</string>
 
 </resources>


### PR DESCRIPTION
## Description
Added complete support for Standing Instructions. Users can now create new standing instructions, get client specific standing instructions and update/delete standing instructions created earlier.
**Note:** Currently the update and create functionality are not working because of Fineract issues

## Screen Recording
### Creating New Standing Instruction
![GIF-200611_213537](https://user-images.githubusercontent.com/46667021/84412685-37545180-ac2d-11ea-8e07-fd49dca9d2e7.gif)
---

### Existing Standing Instruction
![GIF-200611_214251](https://user-images.githubusercontent.com/46667021/84413243-f90b6200-ac2d-11ea-883a-d4fce2a75294.gif)

---

## Screen Shots 
|<img src="https://user-images.githubusercontent.com/46667021/84412852-75ea0c00-ac2d-11ea-9f67-cf0a434dc497.jpeg" width="288" height="500" />|<img src="https://user-images.githubusercontent.com/46667021/84412961-9d40d900-ac2d-11ea-9b2e-361636b81abc.jpeg" width="288" height="500" />|<img src="https://user-images.githubusercontent.com/46667021/84413005-ab8ef500-ac2d-11ea-8380-6e9a81079157.jpeg" width="288" height="500" />|<img src="https://user-images.githubusercontent.com/46667021/84413446-3e2f9400-ac2e-11ea-936a-d56ec06f6aeb.jpeg" width="288" height="500" />|

---

<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
