### PR TITLE
fix: text aligned to left from center in mobile 

### DIFF
--- a/mifospay/src/main/res/layout/fragment_send.xml
+++ b/mifospay/src/main/res/layout/fragment_send.xml
@@ -158,7 +158,7 @@
                     style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                     android:layout_height="60dp"
                     android:layout_marginLeft="@dimen/value_20dp"
-                    android:layout_marginRight="@dimen/value_15dp"
+                    android:layout_marginRight="@dimen/value_20dp"
                     android:layout_toLeftOf="@+id/btn_search_contact"
                     android:textColorHint="@android:color/black"
                     app:hintTextAppearance="@style/TextAppearance.App.TextInputLayout">
@@ -167,11 +167,10 @@
                         android:id="@+id/et_mobile_number"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
-                        android:paddingBottom="@dimen/value_10dp"
+                        android:paddingBottom="@dimen/value_20dp"
                         android:hint="@string/mobile_number"
                         android:inputType="number"
                         android:singleLine="true"
-                        android:textAlignment="center"
                         android:maxLength="@integer/telephone_numbers_max_length_standard"
                         android:textSize="@dimen/value_15sp" />
 


### PR DESCRIPTION
Fixes: #366 
The text is aligned to left in mobile number 
<img src="https://user-images.githubusercontent.com/37215508/84465339-60f49380-ac94-11ea-852f-b61c962d3ed9.gif" width="250" height="400" />

- [.] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [.] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [.] If you have multiple commits please combine them into one commit by squashing them.
