### PR TITLE
Added margin start

### DIFF
--- a/mifospay/src/main/res/layout/activity_bank_account_detail.xml
+++ b/mifospay/src/main/res/layout/activity_bank_account_detail.xml
@@ -110,7 +110,9 @@
             android:layout_marginLeft="@dimen/value_20dp"
             android:background="@drawable/button_round_stroke_primary"
             android:text="@string/setup_upi"
-            android:visibility="visible"/>
+            android:visibility="visible"
+            android:layout_marginStart="@dimen/value_20dp" />
+
 
         <View
             android:layout_width="match_parent"


### PR DESCRIPTION
## Issue Fix
#998 
 
## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->

## Description
This is a warning generated by Android Studio. Though Nothing significant will be solved, It is advisable to use `start ` instead of `left`.

>Consider adding `android:layout_marginStart="@dimen/value_20dp"` to better support right-to-left layouts.
> Using Gravity#LEFT and Gravity#RIGHT can lead to problems when a layout is rendered in locales where text flows from right to left. Use Gravity#START and Gravity#END instead. Similarly, in XML gravity and layout_gravity attributes, use start rather than left.

I am a very beginner in android development, please close this pull request if this doesn't solve anything.
##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.