### PR TITLE
Use TextInputLayout instead of EditText in MobileVerification Activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ For Mac OS, you can use the following commands:
 
 For Windows, you can use the following commands:
 
-* `gradlew check` quality checks on your project’s code using Checkstyle and generates reports from these checks.</br>
-* `gradlew spotlessApply` an check and apply formatting to any plain-text file.</br>
-* `gradlew build`  provides a command line to execute build script.</br>
+* `./gradlew check` quality checks on your project’s code using Checkstyle and generates reports from these checks.</br>
+* `./gradlew spotlessApply` an check and apply formatting to any plain-text file.</br>
+* `./gradlew build`  provides a command line to execute build script.</br>
 
 ## Wiki
 

--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -89,18 +89,33 @@
                 app:ccp_autoDetectCountry="true"
                 app:ccp_autoFormatNumber="false"/>
 
-            <EditText
-                android:id="@+id/et_mobile_number"
-                android:layout_width="wrap_content"
-                android:layout_height="48dp"
-                android:layout_marginLeft="@dimen/value_5dp"
-                android:layout_weight="1"
-                android:background="@drawable/bg_et_round_border"
-                android:hint="@string/mobile_number"
-                android:inputType="number"
-                android:maxLength="@integer/telephone_numbers_max_length_standard"
-                android:paddingLeft="@dimen/value_15dp"
-                android:paddingRight="15dp"/>
+<!--            <EditText-->
+<!--                android:id="@+id/et_mobile_number"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="48dp"-->
+<!--                android:layout_marginLeft="@dimen/value_5dp"-->
+<!--                android:layout_weight="1"-->
+<!--                android:background="@drawable/bg_et_round_border"-->
+<!--                android:hint="@string/mobile_number"-->
+<!--                android:inputType="number"-->
+<!--                android:maxLength="@integer/telephone_numbers_max_length_standard"-->
+<!--                android:paddingLeft="@dimen/value_15dp"-->
+<!--                android:paddingRight="15dp"/>-->
+            <android.support.design.widget.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="160dp"
+                android:layout_height="wrap_content"
+                android:hint="@string/mobile" >
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/et_mobile_number"
+                    android:layout_width="160dp"
+                    android:layout_height="wrap_content"
+                    android:maxLength="@integer/telephone_numbers_max_length_standard"
+                    android:inputType="number" />
+
+            </android.support.design.widget.TextInputLayout>
+
 
             <TextView
                 android:id="@+id/btn_get_otp"
@@ -120,17 +135,32 @@
             android:layout_marginTop="@dimen/value_10dp"
             android:orientation="horizontal">
 
-            <EditText
-                android:id="@+id/et_otp"
+<!--            <EditText-->
+<!--                android:id="@+id/et_otp"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="48dp"-->
+<!--                android:background="@drawable/bg_et_round_border"-->
+<!--                android:hint="@string/enter_otp"-->
+<!--                android:inputType="number"-->
+<!--                android:paddingLeft="15dp"-->
+<!--                android:paddingRight="15dp"-->
+<!--                android:visibility="gone"-->
+<!--                android:maxLength="6"/>-->
+            <android.support.design.widget.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="wrap_content"
                 android:layout_height="48dp"
-                android:background="@drawable/bg_et_round_border"
-                android:hint="@string/enter_otp"
-                android:inputType="number"
-                android:paddingLeft="15dp"
-                android:paddingRight="15dp"
-                android:visibility="gone"
-                android:maxLength="6"/>
+                android:hint="Enter OTP" >
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/et_otp"
+                    android:layout_width="120dp"
+                    android:visibility="gone"
+                    android:layout_height="wrap_content"
+                    android:maxLength="@integer/telephone_numbers_max_length_standard"
+                    android:inputType="number" />
+
+            </android.support.design.widget.TextInputLayout>
 
             <ProgressBar
                 android:id="@+id/progressBar"

--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -89,18 +89,7 @@
                 app:ccp_autoDetectCountry="true"
                 app:ccp_autoFormatNumber="false"/>
 
-<!--            <EditText-->
-<!--                android:id="@+id/et_mobile_number"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="48dp"-->
-<!--                android:layout_marginLeft="@dimen/value_5dp"-->
-<!--                android:layout_weight="1"-->
-<!--                android:background="@drawable/bg_et_round_border"-->
-<!--                android:hint="@string/mobile_number"-->
-<!--                android:inputType="number"-->
-<!--                android:maxLength="@integer/telephone_numbers_max_length_standard"-->
-<!--                android:paddingLeft="@dimen/value_15dp"-->
-<!--                android:paddingRight="15dp"/>-->
+
             <android.support.design.widget.TextInputLayout
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="160dp"
@@ -135,17 +124,7 @@
             android:layout_marginTop="@dimen/value_10dp"
             android:orientation="horizontal">
 
-<!--            <EditText-->
-<!--                android:id="@+id/et_otp"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="48dp"-->
-<!--                android:background="@drawable/bg_et_round_border"-->
-<!--                android:hint="@string/enter_otp"-->
-<!--                android:inputType="number"-->
-<!--                android:paddingLeft="15dp"-->
-<!--                android:paddingRight="15dp"-->
-<!--                android:visibility="gone"-->
-<!--                android:maxLength="6"/>-->
+
             <android.support.design.widget.TextInputLayout
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="wrap_content"

--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -89,18 +89,22 @@
                 app:ccp_autoDetectCountry="true"
                 app:ccp_autoFormatNumber="false"/>
 
-            <EditText
-                android:id="@+id/et_mobile_number"
-                android:layout_width="wrap_content"
-                android:layout_height="48dp"
-                android:layout_marginLeft="@dimen/value_5dp"
-                android:layout_weight="1"
-                android:background="@drawable/bg_et_round_border"
-                android:hint="@string/mobile_number"
-                android:inputType="number"
-                android:maxLength="@integer/telephone_numbers_max_length_standard"
-                android:paddingLeft="@dimen/value_15dp"
-                android:paddingRight="15dp"/>
+
+            <android.support.design.widget.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="160dp"
+                android:layout_height="wrap_content"
+                android:hint="@string/mobile" >
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/et_mobile_number"
+                    android:layout_width="160dp"
+                    android:layout_height="wrap_content"
+                    android:maxLength="@integer/telephone_numbers_max_length_standard"
+                    android:inputType="number" />
+
+            </android.support.design.widget.TextInputLayout>
+
 
             <TextView
                 android:id="@+id/btn_get_otp"
@@ -120,17 +124,22 @@
             android:layout_marginTop="@dimen/value_10dp"
             android:orientation="horizontal">
 
-            <EditText
-                android:id="@+id/et_otp"
+
+            <android.support.design.widget.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="wrap_content"
                 android:layout_height="48dp"
-                android:background="@drawable/bg_et_round_border"
-                android:hint="@string/enter_otp"
-                android:inputType="number"
-                android:paddingLeft="15dp"
-                android:paddingRight="15dp"
-                android:visibility="gone"
-                android:maxLength="6"/>
+                android:hint="Enter OTP" >
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/et_otp"
+                    android:layout_width="120dp"
+                    android:visibility="gone"
+                    android:layout_height="wrap_content"
+                    android:maxLength="@integer/telephone_numbers_max_length_standard"
+                    android:inputType="number" />
+
+            </android.support.design.widget.TextInputLayout>
 
             <ProgressBar
                 android:id="@+id/progressBar"

--- a/mifospay/src/main/res/layout/fragment_send.xml
+++ b/mifospay/src/main/res/layout/fragment_send.xml
@@ -19,7 +19,9 @@
         android:layout_marginBottom="0dp"
         android:orientation="vertical"
         tools:layout_editor_absoluteX="0dp"
-        tools:layout_editor_absoluteY="0dp">
+        tools:layout_editor_absoluteY="0dp"
+        android:layout_alignParentLeft="true"
+        android:layout_marginLeft="0dp">
 
         <TextView
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Issue Fix
Fixes #{Issue Number}
#825 




## Screenshots
![WhatsApp_Image_2020-07-23_at_14 02 43 1](https://user-images.githubusercontent.com/56928954/88266814-7a561a00-cced-11ea-8535-e26855310f86.jpeg)


## Description


<!--Please Add Summary of what changes you have made.-->
![WhatsApp_Image_2020-07-23_at_14 02 43_(1) 1](https://user-images.githubusercontent.com/56928954/88266851-8b069000-cced-11ea-9c28-3e8bb8c23d0d.jpeg)
![WhatsApp_Image_2020-07-23_at_14 02 43_(2) 1](https://user-images.githubusercontent.com/56928954/88266886-9b1e6f80-cced-11ea-89c4-e0dfde685854.jpeg)
![WhatsApp_Image_2020-07-23_at_14 02 44 1](https://user-images.githubusercontent.com/56928954/88266901-a4a7d780-cced-11ea-8ba4-586171b68d24.jpeg)


Description

The EditTexts in activity_mobile_verification has been changed to TexpInputLayouts and TextInputEditTexts for better user experience and understanding.

type:feat,The Phone no and otp editexts have been changed to InputLayouts and InputEditTexts.But the id of each has not been changed so that it functions properly


##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.
