### PR TITLE
TextInputLayout replaced EditText in OTP and MobileNo.Hardcoding remo…

### DIFF
--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -89,18 +89,20 @@
                 app:ccp_autoDetectCountry="true"
                 app:ccp_autoFormatNumber="false"/>
 
-            <EditText
-                android:id="@+id/et_mobile_number"
-                android:layout_width="wrap_content"
-                android:layout_height="48dp"
-                android:layout_marginLeft="@dimen/value_5dp"
-                android:layout_weight="1"
-                android:background="@drawable/bg_et_round_border"
-                android:hint="@string/mobile_number"
-                android:inputType="number"
-                android:maxLength="@integer/telephone_numbers_max_length_standard"
-                android:paddingLeft="@dimen/value_15dp"
-                android:paddingRight="15dp"/>
+            <android.support.design.widget.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="@dimen/value_160dp"
+                android:layout_height="wrap_content"
+                android:hint="@string/mobile" >
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/et_mobile_number"
+                    android:layout_width="@dimen/value_160dp"
+                    android:layout_height="wrap_content"
+                    android:maxLength="@integer/telephone_numbers_max_length_standard"
+                    android:inputType="number" />
+
+            </android.support.design.widget.TextInputLayout>
 
             <TextView
                 android:id="@+id/btn_get_otp"
@@ -120,17 +122,22 @@
             android:layout_marginTop="@dimen/value_10dp"
             android:orientation="horizontal">
 
-            <EditText
-                android:id="@+id/et_otp"
+
+            <android.support.design.widget.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="wrap_content"
-                android:layout_height="48dp"
-                android:background="@drawable/bg_et_round_border"
-                android:hint="@string/enter_otp"
-                android:inputType="number"
-                android:paddingLeft="15dp"
-                android:paddingRight="15dp"
-                android:visibility="gone"
-                android:maxLength="6"/>
+                android:layout_height="@dimen/value_48dp"
+                android:hint="@string/otp" >
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/et_otp"
+                    android:layout_width="@dimen/value_120dp"
+                    android:visibility="gone"
+                    android:layout_height="wrap_content"
+                    android:maxLength="@integer/telephone_numbers_max_length_standard"
+                    android:inputType="number" />
+
+            </android.support.design.widget.TextInputLayout>
 
             <ProgressBar
                 android:id="@+id/progressBar"

--- a/mifospay/src/main/res/values/dimens.xml
+++ b/mifospay/src/main/res/values/dimens.xml
@@ -46,6 +46,8 @@
     <dimen name="value_70dp">70dp</dimen>
     <dimen name="value_100dp">100dp</dimen>
     <dimen name="value_150dp">150dp</dimen>
+    <dimen name="value_160dp">160dp</dimen>
+    <dimen name="value_48dp">48dp</dimen>
     <dimen name="value_13sp">13sp</dimen>
     <dimen name="value_14sp">14sp</dimen>
     <dimen name="value_16sp">16sp</dimen>

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="edit_card">Edit Card</string>
     <string name="delete_card">Delete Card</string>
     <string name="pan_id">PAN ID</string>
-
+    <string name="otp">Enter OTP</string>
     <string name="level_1">Level 1</string>
     <string name="transaction_history">Transaction History</string>
     <string name="history">History</string>


### PR DESCRIPTION
…ved everywhere.

## Issue Fix
Fixes #1015 

## Screenshots
![WhatsApp_Image_2020-07-23_at_14 02 43 1](https://user-images.githubusercontent.com/56928954/88477673-a082f080-cf5f-11ea-8c68-c3054c6ec9db.jpeg)

<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->

## Description
<!--Please Add Summary of what changes you have made.-->
TextInputLayout replaced EditText in OTP and MobileNo.Hardcoding removed everywhere

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
