### PR TITLE
Fix: Removed unused and redundant namespace declarations in XML files

### DIFF
--- a/mifospay/src/main/res/layout/activity_link_bank_account.xml
+++ b/mifospay/src/main/res/layout/activity_link_bank_account.xml
@@ -25,8 +25,7 @@
             android:layout_height="match_parent"
             android:scrollbars="vertical">
 
-            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                          xmlns:app="http://schemas.android.com/apk/res-auto"
+            <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
                           android:layout_width="match_parent"
                           android:layout_height="match_parent"
                           android:background="@color/grey_50"

--- a/mifospay/src/main/res/layout/activity_login.xml
+++ b/mifospay/src/main/res/layout/activity_login.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:onClick="backgroundScreenClicked"
     android:id="@+id/bg_screen"
     android:layout_width="match_parent"

--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -16,8 +16,6 @@
             android:background="@color/primaryDarkBlue">
 
             <android.support.v7.widget.Toolbar
-                xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/mifospay/src/main/res/layout/activity_show_qr.xml
+++ b/mifospay/src/main/res/layout/activity_show_qr.xml
@@ -2,7 +2,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">
 
     <include layout="@layout/toolbar"/>

--- a/mifospay/src/main/res/layout/activity_signup.xml
+++ b/mifospay/src/main/res/layout/activity_signup.xml
@@ -19,8 +19,6 @@
                 android:background="@color/primaryDarkBlue">
 
                 <android.support.v7.widget.Toolbar
-                    xmlns:android="http://schemas.android.com/apk/res/android"
-                    xmlns:app="http://schemas.android.com/apk/res-auto"
                     android:id="@+id/toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/mifospay/src/main/res/layout/dialog_setup_upi_pin.xml
+++ b/mifospay/src/main/res/layout/dialog_setup_upi_pin.xml
@@ -11,9 +11,7 @@
         android:focusableInTouchMode="true"
         android:orientation="vertical">
 
-        <LinearLayout
-            xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
+        <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
             android:id="@+id/ll_debit_card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -84,9 +82,7 @@
 
         </LinearLayout>
 
-        <LinearLayout
-            xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
+        <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
             android:id="@+id/ll_otp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -129,9 +125,7 @@
 
         </LinearLayout>
 
-        <LinearLayout
-            xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
+        <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
             android:id="@+id/upi"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/mifospay/src/main/res/layout/fragment_merchants.xml
+++ b/mifospay/src/main/res/layout/fragment_merchants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/mifospay/src/main/res/layout/fragment_send.xml
+++ b/mifospay/src/main/res/layout/fragment_send.xml
@@ -7,8 +7,7 @@
     android:background="@color/colorPrimary"
     android:orientation="vertical">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_alignParentStart="true"


### PR DESCRIPTION
Fixes #1035 

**Summary**
Removed redundant and unused namespace declarations in XML files.

Please make sure these boxes are checked before submitting your pull request - thanks!

 

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 


- [x] Run the unit tests with `./gradlew` check to make sure you didn't break anything

 

- [x] If you have multiple commits please combine them into one commit by squashing them.
