### PR TITLE
fix: VPA String validation

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
@@ -146,6 +146,10 @@ public class SendFragment extends BaseFragment implements BaseHomeContract.Trans
                 showSnackbar(Constants.PLEASE_ENTER_VALID_AMOUNT);
                 return;
             }
+            if (!externalId.matches(Constants.VPA_VALIDATION_REGEX)) {
+                showSnackbar(getString(R.string.please_enter_valid_vpa));
+                return;
+            }
             if (!mTransferPresenter.checkSelfTransfer(externalId)) {
                 mTransferPresenter.checkBalanceAvailability(externalId, amount);
             } else {

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
@@ -73,6 +73,7 @@ public class Constants {
     public static final String ERROR_FINDING_VPA = "Error finding Virtual Payment Address";
     public static final String ERROR_FINDING_MOBILE_NUMBER = "Error finding Mobile Number";
     public static final String PLEASE_ENTER_VALID_AMOUNT = "Please enter a valid amount";
+    public static final String VPA_VALIDATION_REGEX = "^\\w.+@\\w+$";
     public static final String SELF_ACCOUNT_ERROR = "Self Account transfer is not allowed";
     public static final String PLEASE_ENTER_AMOUNT =
             "Please enter a valid amount before making the transfer";

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -274,6 +274,7 @@
     <string name="no_bank_account">No bank found</string>
     <string name="error_specific_transactions">Couldn\'t fetch Specific transactions. Please, try again.</string>
     <string name="fetching_history">Fetching History...</string>
+    <string name="please_enter_valid_vpa">Please enter a valid VPA</string>
     <string name="tile_si_activity">Create Standing Instruction</string>
     <string name="standing_instruction">SI</string>
     <string name="valid_till">Valid till :</string>


### PR DESCRIPTION
## Issue Fix
Fixes #1037

## ScreenRecording
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/62820147/97067561-07a25680-15dc-11eb-894a-e0550291b1c3.gif)


## Description
Added VPA string validation with Regex.
Now App shows a snackbar ( Please enter a valid VPA) **Instantly** whenever user tries to input an invalid vpa.
##

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
