### PR TITLE
Alinged the Hint in the box in fragment_send.xml

### DIFF
--- a/mifospay/src/main/res/layout/fragment_send.xml
+++ b/mifospay/src/main/res/layout/fragment_send.xml
@@ -87,10 +87,9 @@
             <android.support.design.widget.TextInputLayout
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
-                android:layout_height="80dp"
+                android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/value_20dp"
                 android:layout_marginRight="@dimen/value_20dp"
-                android:padding="@dimen/value_10dp"
                 android:textColorHint="@android:color/black"
                 app:hintTextAppearance="@style/TextAppearance.App.TextInputLayout">
 
@@ -100,7 +99,6 @@
                     android:layout_height="match_parent"
                     android:hint="@string/amount"
                     android:inputType="number"
-                    android:paddingBottom="@dimen/value_20dp"
                     android:textSize="@dimen/value_15sp" />
             </android.support.design.widget.TextInputLayout>
 
@@ -113,9 +111,8 @@
                     android:id="@+id/til_vpa"
                     style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                     android:layout_width="270dp"
-                    android:layout_height="90dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginLeft="@dimen/value_20dp"
-                    android:padding="@dimen/value_10dp"
                     android:textColorHint="@android:color/black"
                     app:hintTextAppearance="@style/TextAppearance.App.TextInputLayout">
 


### PR DESCRIPTION
## Issue Fix
Fixes #1052

## Screenshots
![Screenshot_20201116-121228_Mifos Pay](https://user-images.githubusercontent.com/54978105/99220826-676bd600-2805-11eb-8e16-9229979fb0e6.jpg)


## Description
Now the hints are aligned inside the box

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
