### PR TITLE
Added a Toast when no of the sim is selected and confirm is pressed

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/ui/ChooseSimDialog.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/ui/ChooseSimDialog.java
@@ -8,6 +8,7 @@ import android.support.design.widget.BottomSheetDialogFragment;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.mifos.mobilewallet.mifospay.R;
 
@@ -75,8 +76,10 @@ public class ChooseSimDialog extends BottomSheetDialogFragment {
     @OnClick(R.id.btn_confirm)
     public void onConfirmClicked() {
         dismiss();
-        if (getActivity() instanceof LinkBankAccountActivity) {
+        if (getActivity() instanceof LinkBankAccountActivity && (selectedSim==1 || selectedSim==2)) {
             ((LinkBankAccountActivity) getActivity()).linkBankAccount(selectedSim);
+        } else {
+            Toast.makeText(getContext().getApplicationContext(),getString(R.string.choose_sim),Toast.LENGTH_SHORT).show();
         }
     }
 }

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -292,6 +292,7 @@
     <string name="enter_VPA">Please enter the VPA</string>
     <string name="amount_header">Amount:</string>
     <string name="deleted_successfully">Deleted Successfully</string>
+    <string name="choose_sim">Choose a Sim</string>
 
     <!-- dynamically formatted strings-->
     <string name="name_client_name">Name: %1$s</string>


### PR DESCRIPTION
## Issue Fix
Fixes #358 #375 

## Description
I have added the toast message string **Choose a Sim** in strings.xml and in ChooseSimDialog.java I checked whether any sim is selected or not before pressing **Confirm**. If not this message will be displayed instead of the progresssDialog.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
