### PR TITLE
Adding requestFocus and setError to Amount, VPA and mobile number edi…

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
@@ -8,6 +8,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -82,6 +83,8 @@ public class SendFragment extends BaseFragment implements BaseHomeContract.Trans
 
     private String vpa;
 
+    Handler handler = new Handler();
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -136,10 +139,38 @@ public class SendFragment extends BaseFragment implements BaseHomeContract.Trans
         String eamount = etAmount.getText().toString().trim();
         String mobileNumber = mEtMobileNumber.getText()
                 .toString().trim().replaceAll("\\s+", "");
-        if (eamount.equals("") || (mBtnVpa.isSelected() && externalId.equals("")) ||
-                (mBtnMobile.isSelected() && mobileNumber.equals(""))) {
-            Toast.makeText(getActivity(),
-                    Constants.PLEASE_ENTER_ALL_THE_FIELDS, Toast.LENGTH_SHORT).show();
+        if (eamount.equals("")) {
+            etAmount.setError(getString(R.string.please_enter_amount));
+            etAmount.requestFocus();
+            handler.postDelayed(new Runnable() {
+                public void run() {
+                    etAmount.setError(null);
+                    etAmount.clearFocus();
+                }
+            }, 1500);
+            return;
+        }
+        if (externalId.equals("") && mBtnVpa.isSelected()) {
+            etVpa.setError(getString(R.string.please_enter_VPA));
+            etVpa.requestFocus();
+            handler.postDelayed(new Runnable() {
+                public void run() {
+                    etVpa.setError(null);
+                    etVpa.clearFocus();
+                }
+            }, 1500);
+            return;
+        }
+        if (mobileNumber.equals("") && mBtnMobile.isSelected()) {
+            mEtMobileNumber.setError(getString(R.string.please_enter_mobile_number));
+            mEtMobileNumber.requestFocus();
+            handler.postDelayed(new Runnable() {
+                public void run() {
+                    mEtMobileNumber.setError(null);
+                    mEtMobileNumber.clearFocus();
+                }
+            }, 1500);
+            return;
         } else {
             double amount = Double.parseDouble(eamount);
             if (amount <= 0) {

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
@@ -24,7 +24,6 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.mifos.mobilewallet.mifospay.R;
 import org.mifos.mobilewallet.mifospay.base.BaseActivity;

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -292,6 +292,9 @@
     <string name="enter_VPA">Please enter the VPA</string>
     <string name="amount_header">Amount:</string>
     <string name="deleted_successfully">Deleted Successfully</string>
+    <string name="please_enter_amount">Please enter amount</string>
+    <string name="please_enter_VPA">Please enter VPA</string>
+    <string name="please_enter_mobile_number">Please enter mobile number</string>
 
     <!-- dynamically formatted strings-->
     <string name="name_client_name">Name: %1$s</string>


### PR DESCRIPTION

## Issue Fix
Fixes #1088

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->
![WhatsApp Image 2020-12-24 at 2 07 22 AM (3)](https://user-images.githubusercontent.com/50478348/103037842-d1109a00-4592-11eb-9a08-aee20136e82a.jpeg)
![WhatsApp Image 2020-12-24 at 2 07 22 AM (2)](https://user-images.githubusercontent.com/50478348/103037864-e259a680-4592-11eb-81b7-31783e83821e.jpeg)
![WhatsApp Image 2020-12-24 at 2 07 22 AM (1)](https://user-images.githubusercontent.com/50478348/103037877-eb4a7800-4592-11eb-8126-da7edb605aeb.jpeg)
![WhatsApp Image 2020-12-24 at 2 07 22 AM](https://user-images.githubusercontent.com/50478348/103037879-ebe30e80-4592-11eb-963e-5110178a2462.jpeg)

## Description
<!--Please Add Summary of what changes you have made.-->
I have added request focus and set error to each edit text field if the fields are empty. After 1.5 sec the message will get closed.
##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
