### PR TITLE
Confirmation Dialog added before deleting a SI

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIDetailsActivity.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIDetailsActivity.kt
@@ -247,10 +247,7 @@ class SIDetailsActivity : BaseActivity(), StandingInstructionContract.SIDetailsV
                 /**
                  * perform delete action only when details have been successfully fetched
                  */
-                if (this.standingInstructionId != 0L) {
-                    mStandingInstructionPresenter.deleteStandingInstruction(
-                            this.standingInstructionId)
-                }
+                showConfirmDeleteDialog()
             else -> return super.onOptionsItemSelected(item)
         }
         return true
@@ -262,6 +259,21 @@ class SIDetailsActivity : BaseActivity(), StandingInstructionContract.SIDetailsV
         } else {
             super.onBackPressed()
         }
+    }
+
+    private fun showConfirmDeleteDialog() {
+        val dialogBox = DialogBox()
+        dialogBox.setOnPositiveListener { dialog, which ->
+            if (this.standingInstructionId != 0L) {
+                mStandingInstructionPresenter.deleteStandingInstruction(
+                        this.standingInstructionId)
+            }
+        }
+        dialogBox.setOnNegativeListener { dialog, which ->
+            dialog.dismiss()
+        }
+        dialogBox.show(this, R.string.delete_standing_instruction,
+                R.string.delete_standing_instruction_confirm, R.string.accept, R.string.cancel)
     }
 
     private fun showDiscardChangesDialog() {

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -286,6 +286,7 @@
     <string name="discard_and_exit">This will discard all unsaved changes</string>
     <string name="interval_cannot_smaller_than_1_month">Interval cannot be smaller than 1 Month</string>
     <string name="delete_standing_instruction">Delete Standing Instruction</string>
+    <string name="delete_standing_instruction_confirm">This will delete the Standing Instruction</string>
     <string name="pick_the_date"><u>pick the date</u></string>
     <string name="empty_standing_instructions">No standing instructions to show</string>
     <string name="select_till_date">Kindly select Till Date</string>


### PR DESCRIPTION
## Issue Fix
Fixes #1104

## Screenshots

https://user-images.githubusercontent.com/50913976/103692589-fbfce400-4fbd-11eb-990b-8ae7ba6e01d4.mp4

## Description
Added a confirmation dialog before an SI is deleted

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
