### PR TITLE
Crash on pressing back button before fetching of data fixed

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIDetailsActivity.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIDetailsActivity.kt
@@ -198,6 +198,9 @@ class SIDetailsActivity : BaseActivity(), StandingInstructionContract.SIDetailsV
     }
 
     private fun isDataSaveNecessary(): Boolean {
+        if (!this::standingInstruction.isInitialized) {
+            return false
+        }
         val originalValidTillDate = "${standingInstruction.validTill?.get(2)}-" +
                 "${standingInstruction.validTill?.get(1)}-${standingInstruction.validTill?.get(0)}"
 


### PR DESCRIPTION
## Issue Fix
Fixes #1108 

## Screenshots

https://user-images.githubusercontent.com/50913976/103694918-b93d0b00-4fc1-11eb-9596-bf568b1dda8e.mp4

## Description
Checked whether the lateint standingInstruction is initialised before accessing it

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
