### PR TITLE
Close image will be replaced by down image.

### DIFF
--- a/mifospay/src/main/res/drawable/ic_down_arrow.xml
+++ b/mifospay/src/main/res/drawable/ic_down_arrow.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="220.682dp"
+    android:height="220.682dp"
+    android:viewportWidth="220.682"
+    android:viewportHeight="220.682">
+    <path
+        android:fillColor="#1C3AE3"
+        android:pathData="M110.341,220.682l99.702,-99.702l-28.285,-28.285l-71.417,71.418l-71.417,-71.418l-28.285,28.285z"/>
+    <path
+        android:fillColor="#1C3AE3"
+        android:pathData="M210.043,28.284l-28.285,-28.284l-71.417,71.418l-71.417,-71.418l-28.285,28.284l99.702,99.702z"/>
+</vector>

--- a/mifospay/src/main/res/layout/fragment_make_transfer.xml
+++ b/mifospay/src/main/res/layout/fragment_make_transfer.xml
@@ -127,7 +127,7 @@
             android:layout_gravity="center"
             android:layout_marginBottom="@dimen/value_20dp"
             android:layout_marginTop="@dimen/value_20dp"
-            android:background="@drawable/transfer_failure"
+            android:background="@drawable/ic_down_arrow"
             android:visibility="gone"/>
 
         <ProgressBar


### PR DESCRIPTION

![WhatsApp Image 2021-01-06 at 13 22 12](https://user-images.githubusercontent.com/56928954/103745112-ea025c00-5024-11eb-9887-73d05bb39dda.jpeg)
## Issue Fix
Fixes #769 

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->

## Description
<!--Please Add Summary of what changes you have made.-->
This particular image confuses me to click it. When I click it, nothing happens. Later, I learnt it is to swipe. So we can add a swipe down arrow image so that user will swipe down.I have not made the bottom sheet to close after 3 seconds as it might confuse the user.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
