### PR TITLE
fix:#1137 Heading size change in activity_si_details

### DIFF
--- a/mifospay/src/main/res/layout/activity_si_details.xml
+++ b/mifospay/src/main/res/layout/activity_si_details.xml
@@ -30,7 +30,7 @@
                     android:layout_height="wrap_content"
                     android:layout_margin="@dimen/marginItemsInSectionMedium"
                     android:textColor="@color/black"
-                    android:textSize="40sp"
+                    android:textSize="@dimen/value_30sp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
## Issue Fix
Fixes #1137 

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->

## Description
<!--Please Add Summary of what changes you have made.-->
The title size has been changed from 40sp to 30sp in order for the user to read the heading properly

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
![changed size](https://user-images.githubusercontent.com/56928954/104116528-63f55680-533f-11eb-8a4d-4c14afef7c6c.jpeg)
