### PR TITLE
Fix : #1088 Adding Toasts for perticular edittext field

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
@@ -136,10 +136,20 @@ public class SendFragment extends BaseFragment implements BaseHomeContract.Trans
         String eamount = etAmount.getText().toString().trim();
         String mobileNumber = mEtMobileNumber.getText()
                 .toString().trim().replaceAll("\\s+", "");
-        if (eamount.equals("") || (mBtnVpa.isSelected() && externalId.equals("")) ||
-                (mBtnMobile.isSelected() && mobileNumber.equals(""))) {
+        if (eamount.equals("")) {
             Toast.makeText(getActivity(),
-                    Constants.PLEASE_ENTER_ALL_THE_FIELDS, Toast.LENGTH_SHORT).show();
+                    Constants.EMPTY_AMOUNT, Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (externalId.equals("") && mBtnVpa.isSelected()) {
+            Toast.makeText(getActivity(),
+                    Constants.EMPTY_VPA, Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (mobileNumber.equals("") && mBtnMobile.isSelected()) {
+            Toast.makeText(getActivity(),
+                    Constants.EMPTY_MOBILE_NUMBER, Toast.LENGTH_SHORT).show();
+            return;
         } else {
             double amount = Double.parseDouble(eamount);
             if (amount <= 0) {

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
@@ -82,6 +82,9 @@ public class Constants {
     public static final String ERROR_CHOOSING_CONTACT = "Error choosing contact";
     public static final String MAKE_TRANSFER_FRAGMENT = "Make Transfer Fragment";
     public static final String PLEASE_ENTER_ALL_THE_FIELDS = "Please enter all the fields";
+    public static final String EMPTY_AMOUNT = "Please enter amount";
+    public static final String EMPTY_VPA = "Please enter VPA";
+    public static final String EMPTY_MOBILE_NUMBER = "Please enter mobile number";
     public static final String TRANSFER = "Transfer";
     public static final String TRANSACTION_DETAILS = "Transaction Details";
     public static final String ACCOUNT_NUMBER = "Account Number : ";


### PR DESCRIPTION
## Issue Fix
Fixes #1088

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->
![WhatsApp Image 2021-01-10 at 1 21 57 PM (2)](https://user-images.githubusercontent.com/50478348/104117404-111f9d00-5347-11eb-8489-93bf962b2d0d.jpeg)
![WhatsApp Image 2021-01-10 at 1 21 57 PM (1)](https://user-images.githubusercontent.com/50478348/104117406-12e96080-5347-11eb-9fe9-4695d9b0f3dc.jpeg)
![WhatsApp Image 2021-01-10 at 1 21 57 PM](https://user-images.githubusercontent.com/50478348/104117410-18df4180-5347-11eb-9091-8a00e0a8342c.jpeg)



## Description
<!--Please Add Summary of what changes you have made.-->
Added Toast for particular edittext if it is kept empty in sendFragment in payments.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
