### PR TITLE
fix:#1156 Share and copy button moved adjacent to receipt title

### DIFF
--- a/mifospay/src/main/res/layout/activity_receipt.xml
+++ b/mifospay/src/main/res/layout/activity_receipt.xml
@@ -140,7 +140,8 @@
 
                         <android.support.constraint.ConstraintLayout
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content">
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="@dimen/value_80dp">
 
                             <TextView
                                 android:id="@+id/tv_transaction_reciept"

--- a/mifospay/src/main/res/values/dimens.xml
+++ b/mifospay/src/main/res/values/dimens.xml
@@ -47,6 +47,7 @@
     <dimen name="value_30sp">30sp</dimen>
     <dimen name="value_2dp">2dp</dimen>
     <dimen name="value_70dp">70dp</dimen>
+    <dimen name="value_80dp">80dp</dimen>
     <dimen name="value_100dp">100dp</dimen>
     <dimen name="value_150dp">150dp</dimen>
     <dimen name="value_13sp">13sp</dimen>


### PR DESCRIPTION
## Issue Fix
Fixes #1156 
![WhatsApp Image 2021-01-15 at 17 09 39](https://user-images.githubusercontent.com/56928954/104723140-ccd03a80-5754-11eb-8dde-611fcf4ae989.jpeg)


## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->

## Description
<!--Please Add Summary of what changes you have made.-->
The share and copy buttons have been moved adjacent to the title of the unique receipt so that the download button doesnt cover it up.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
