### PR TITLE
Removed Profile picture edit button from Profile Fragment

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/ProfileFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/ProfileFragment.java
@@ -144,6 +144,8 @@ public class ProfileFragment extends BaseFragment implements BaseHomeContract.Pr
                 .width((int) getResources().getDimension(R.dimen.user_profile_image_size))
                 .height((int) getResources().getDimension(R.dimen.user_profile_image_size))
                 .endConfig().buildRound(client.getName().substring(0, 1), R.color.colorAccentBlack);
+        ImageView editableImageHint=getView().findViewById(R.id.iv_editable_image_hint);
+        editableImageHint.setVisibility(View.INVISIBLE);
         ivUserImage.setImageDrawable(drawable);
         tvUserName.setText(client.getName());
     }


### PR DESCRIPTION

Fixes #1158 : Removed profile picture edit button from profile fragment.


![Screenshot_2021-01-15-14-41-17-379_org mifos mobilewallet mifospay](https://user-images.githubusercontent.com/54908741/104706044-a1dbeb80-5740-11eb-813d-b88de5cbf8b6.jpg)
![Screenshot_2021-01-15-14-41-22-412_org mifos mobilewallet mifospay](https://user-images.githubusercontent.com/54908741/104706054-a56f7280-5740-11eb-9fbc-92e35be17a45.jpg)


##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
