### PR TITLE
fix#1216:Minimum Date in *Valid Till* DatePicker fixed.

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIDetailsActivity.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/standinginstruction/ui/SIDetailsActivity.kt
@@ -19,6 +19,7 @@ import org.mifos.mobilewallet.mifospay.standinginstruction.presenter.StandingIns
 import org.mifos.mobilewallet.mifospay.utils.Constants
 import org.mifos.mobilewallet.mifospay.utils.DialogBox
 import org.mifos.mobilewallet.mifospay.utils.Utils
+import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
 
@@ -40,6 +41,7 @@ class SIDetailsActivity : BaseActivity(), StandingInstructionContract.SIDetailsV
     lateinit var mPresenter: StandingInstructionDetailsPresenter
     private lateinit var mStandingInstructionPresenter:
             StandingInstructionContract.StandingInstructorDetailsPresenter
+    private lateinit var mOptionsMenu: Menu
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -68,6 +70,7 @@ class SIDetailsActivity : BaseActivity(), StandingInstructionContract.SIDetailsV
                     DatePickerDialog.OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
                         tv_valid_till.text = "$dayOfMonth-${(monthOfYear + 1)}-$year"
                     }, year, month, day)
+            picker.datePicker.minDate = SimpleDateFormat("dd-MM-yyyy",Locale.getDefault()).parse(tv_valid_from.text.toString()).time
             picker.show()
         }
 


### PR DESCRIPTION
## Issue Fix
Fixes #1216 

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->
![WhatsApp Image 2021-02-10 at 01 23 36](https://user-images.githubusercontent.com/56928954/107421077-93b29c80-6b3f-11eb-85b5-96c43ba6d5af.jpeg)


## Description
<!--Please Add Summary of what changes you have made.-->
The valid Till DatePicker Dialogues has been fixed so that the valid till date is chronologically never less than valid from.
Few additional warnings have also been rectified along the way

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
