### PR TITLE
Fix#1218 : align share and copy ImageViews with receipt heading

### DIFF
--- a/mifospay/src/main/res/layout/activity_receipt.xml
+++ b/mifospay/src/main/res/layout/activity_receipt.xml
@@ -130,25 +130,16 @@
                             android:textSize="@dimen/value_16sp"
                             android:layout_marginBottom="@dimen/marginItemsInSectionMedium" />
 
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:textColor="@color/gray_dark"
-                            android:textSize="@dimen/value_16sp"
-                            android:text="@string/unique_receipt_link"/>
-
                         <android.support.constraint.ConstraintLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content">
 
-                            <TextView
-                                android:id="@+id/tv_transaction_reciept"
+                            <TextView android:id="@+id/unqReceiptLinkTV"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_marginBottom="@dimen/marginItemsInSectionMedium"
-                                android:textColor="@color/primaryBlue"
+                                android:textColor="@color/gray_dark"
                                 android:textSize="@dimen/value_16sp"
+                                android:text="@string/unique_receipt_link"
                                 app:layout_constrainedWidth="true"
                                 app:layout_constraintEnd_toStartOf="@id/transaction_reciept_copy"
                                 app:layout_constraintHorizontal_bias="0"
@@ -166,7 +157,7 @@
                                 android:clickable="true"
                                 android:fitsSystemWindows="true"
                                 app:layout_constraintEnd_toStartOf="@id/transaction_reciept_share"
-                                app:layout_constraintStart_toEndOf="@id/tv_transaction_reciept"
+                                app:layout_constraintStart_toEndOf="@id/unqReceiptLinkTV"
                                 app:layout_constraintTop_toTopOf="parent"
                                 app:srcCompat="@drawable/ic_baseline_content_copy_24" />
 
@@ -184,6 +175,14 @@
                                 app:layout_constraintTop_toTopOf="parent"
                                 app:srcCompat="@drawable/ic_baseline_share_24" />
                         </android.support.constraint.ConstraintLayout>
+
+                        <TextView
+                            android:id="@+id/tv_transaction_reciept"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="@dimen/marginItemsInSectionMedium"
+                            android:textColor="@color/primaryBlue"
+                            android:textSize="@dimen/value_16sp"/>
                     </LinearLayout>
                 </LinearLayout>
 


### PR DESCRIPTION
## Issue Fix
Fixes #1218 

## Screenshots
<img src="https://user-images.githubusercontent.com/56648862/107524758-24d75100-6bdc-11eb-9907-8a0dd9390ee5.jpeg" width="200" height="400"/>


## Description
aligned share and copy ImageViews with receipt heading because that was the most suitable position according to the structure of the activity.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
