### PR TITLE
fix#1236:Progress dialog box disappear if debit card number is invalid

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/fragment/DebitCardFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/fragment/DebitCardFragment.java
@@ -95,6 +95,8 @@ public class DebitCardFragment extends BaseFragment implements BankContract.Debi
 
     @Override
     public void verifyDebitCardError(String message) {
+        hideProgressDialog();
+        mEtDebitCardNumber.requestFocusFromTouch();
         showToast(message);
     }
 


### PR DESCRIPTION
## Issue Fix
Fixes #1236

## Screenshots

https://user-images.githubusercontent.com/71138679/108109153-8bb2a980-70b7-11eb-85b9-4907e8f7456d.mp4



## Description
The progress dialog box now disappears if debit card number is invalid, the focus shifts to edit the debit card number. It makes it easier for the user to correct the invalid card number.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
