### PR TITLE
Fixed progress dialog box bug and textview bug

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/SignupActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/SignupActivity.java
@@ -223,9 +223,9 @@ public class SignupActivity extends BaseActivity implements RegistrationContract
         if (mEtPassword.getText().toString().length() < 6) {
             showToast("Password should contain more than 6 characters");
             
-             //when toast message is being shown then progressdialog of "please wait " must not be shown or it should be
-            //cancelled automatically after toast message
-            hideProgressDialog();////
+           
+            //hide dilaog after toast message
+            hideProgressDialog();
             
             return;
         }

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/SignupActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/SignupActivity.java
@@ -222,6 +222,11 @@ public class SignupActivity extends BaseActivity implements RegistrationContract
         }
         if (mEtPassword.getText().toString().length() < 6) {
             showToast("Password should contain more than 6 characters");
+            
+             //when toast message is being shown then progressdialog of "please wait " must not be shown or it should be
+            //cancelled automatically after toast message
+            hideProgressDialog();////
+            
             return;
         }
 

--- a/mifospay/src/main/res/drawable/bottomview_selector.xml
+++ b/mifospay/src/main/res/drawable/bottomview_selector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/colorPrimary" android:state_pressed="true"/>
-    <item android:color="@color/colorPrimary" android:state_checked="true"/>
-    <item android:color="#80CCCCD8"/>
+    <item android:color="@color/colorAccent" android:state_pressed="true"/>
+    <item android:color="@color/colorAccent" android:state_checked="true"/>
+    <item android:color="@color/colorAccentBlue50"/>
 </selector>

--- a/mifospay/src/main/res/drawable/bottomview_selector.xml
+++ b/mifospay/src/main/res/drawable/bottomview_selector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/colorAccent" android:state_pressed="true"/>
-    <item android:color="@color/colorAccent" android:state_checked="true"/>
-    <item android:color="@color/colorAccentBlue50"/>
+    <item android:color="@color/colorPrimary" android:state_pressed="true"/>
+    <item android:color="@color/colorPrimary" android:state_checked="true"/>
+    <item android:color="#80CCCCD8"/>
 </selector>

--- a/mifospay/src/main/res/layout/activity_home.xml
+++ b/mifospay/src/main/res/layout/activity_home.xml
@@ -30,7 +30,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-             android:background="@color/colorAccentBlue50"
+             android:background="@color/colorPrimary"
             app:elevation="25dp"
             app:itemIconTint="@drawable/bottomview_selector"
             app:itemTextColor="@drawable/bottomview_selector"

--- a/mifospay/src/main/res/layout/activity_home.xml
+++ b/mifospay/src/main/res/layout/activity_home.xml
@@ -30,7 +30,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            android:background="@color/colorPrimary"
+             android:background="@color/colorAccentBlue50"
             app:elevation="25dp"
             app:itemIconTint="@drawable/bottomview_selector"
             app:itemTextColor="@drawable/bottomview_selector"

--- a/mifospay/src/main/res/layout/activity_signup.xml
+++ b/mifospay/src/main/res/layout/activity_signup.xml
@@ -128,6 +128,8 @@
                     android:layout_width="match_parent"
                     android:id="@+id/tv_password_strength"
                     android:gravity="center"
+                    android:paddingBottom="4dp"
+                    android:paddingTop="4dp"
                     android:visibility="gone"
                     android:layout_marginBottom="8dp"
                     android:layout_height="wrap_content" />


### PR DESCRIPTION


## Issues Fixed




## Description
# issue 1- 
 In sign up activity when toast message is being shown " password should contain more than 6 characters"  then progress dialog of " please wait" must not be shown or it should be cancelled automatically after Toast message .

#1240 Screen Recordings

https://user-images.githubusercontent.com/65856435/109483625-7e2cf480-7aa5-11eb-87be-9a0f9afb0f66.mp4

I have fixed this issue now progress dialog will not be shown till password is 6 characters long.


# issue 2-
In Sign Up Xml file text view of id "android:id="@+id/tv_password_strength" which was showing "weak, strong , very strong and password should contain 6 characters " was getting overlapped sometimes with the confirm password edit text or sometime with progress bar just above it.

## Screenshots

![1614598456600](https://user-images.githubusercontent.com/65856435/109495594-7ffeb400-7ab5-11eb-836b-d2eba1186c10.jpg)

![1614598456608](https://user-images.githubusercontent.com/65856435/109495558-74ab8880-7ab5-11eb-86c2-34a7d269abb5.jpg)

fixed



##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
