### PR TITLE
Progress Dialog box bug fixed.

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/SignupActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/SignupActivity.java
@@ -222,6 +222,9 @@ public class SignupActivity extends BaseActivity implements RegistrationContract
         }
         if (mEtPassword.getText().toString().length() < 6) {
             showToast("Password should contain more than 6 characters");
+            
+             //hide automatically after toast message
+            hideProgressDialog();////
             return;
         }
 


### PR DESCRIPTION
In Sign up activity after toast message "Password should contain more than 6 characters"   "please wait " dialog must not ne shown or it should be hide automatically after toast message.

## Issue Fix
Fixes #{Issue Number}

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->

## Description
<!--Please Add Summary of what changes you have made.-->
 if (mEtPassword.getText().toString().length() < 6) {
            showToast("Password should contain more than 6 characters");

          
            hideProgressDialog();////      I have just added this line

            return;
        }

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
