### PR TITLE
text view bug fixed #1250

### DIFF
--- a/mifospay/src/main/res/layout/activity_signup.xml
+++ b/mifospay/src/main/res/layout/activity_signup.xml
@@ -127,6 +127,8 @@
                 <TextView
                     android:layout_width="match_parent"
                     android:id="@+id/tv_password_strength"
+                    android:paddingBottom="4dp"
+                    android:paddingTop="4dp"
                     android:gravity="center"
                     android:visibility="gone"
                     android:layout_marginBottom="8dp"


### PR DESCRIPTION



## Issue Fix
Fixes #1250 

## Screenshots



![1614598456600](https://user-images.githubusercontent.com/65856435/110214838-7b2e6b80-7ecc-11eb-8556-70cec7f6fd64.jpg)

## Description
<!--Please Add Summary of what changes you have made.-->
In Sign Up Xml file text view of id "android:id="@+id/tv_password_strength" which was showing "weak, strong , very strong and password should contain 6 characters " was getting overlapped sometimes with the confirm password edit text or sometime with progress bar just above it. #1250

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
