### PR TITLE
fix#1255:The max size in phone no removed

### DIFF
--- a/mifospay/src/main/res/layout/fragment_send.xml
+++ b/mifospay/src/main/res/layout/fragment_send.xml
@@ -168,7 +168,6 @@
                         android:inputType="number"
                         android:singleLine="true"
                         android:textAlignment="center"
-                        android:maxLength="@integer/telephone_numbers_max_length_standard"
                         android:textSize="@dimen/value_15sp" />
 
                 </android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
## Issue Fix
Fixes #1255 

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->
![WhatsApp Image 2021-03-07 at 00 49 32 (1)](https://user-images.githubusercontent.com/56928954/110218638-d702ef80-7ee0-11eb-97a8-d77f52780eb7.jpeg)


## Description
<!--Please Add Summary of what changes you have made.-->
The maximum size in phone number removed.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
