### PR TITLE
changed the dimen of acitivty_mobile_verification

### DIFF
--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -37,7 +37,7 @@
                     app:ccp_showFullName="true"
                     app:ccp_showNameCode="false"
                     app:ccp_showPhoneCode="false"
-                    app:ccp_textGravity="CENTER"/>
+                    app:ccp_textGravity="CENTER" />
 
             </android.support.v7.widget.Toolbar>
 
@@ -62,11 +62,11 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/value_10dp"
                     android:layout_marginTop="@dimen/value_5dp"
+                    android:layout_marginBottom="@dimen/value_10dp"
                     android:text="@string/enter_mobile_number_description"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/value_14sp"/>
+                    android:textSize="@dimen/value_14sp" />
 
             </LinearLayout>
 
@@ -76,31 +76,33 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/value_10dp"
-            android:layout_marginRight="@dimen/value_10dp"
             android:layout_marginTop="@dimen/value_20dp"
+            android:layout_marginRight="@dimen/value_10dp"
             android:orientation="horizontal">
 
             <com.hbb20.CountryCodePicker
                 android:id="@+id/ccp_code"
+                android:layout_weight="0"
                 android:layout_width="wrap_content"
                 android:layout_height="48dp"
                 android:layout_gravity="center_vertical"
                 android:gravity="center_vertical"
                 app:ccp_autoDetectCountry="true"
-                app:ccp_autoFormatNumber="false"/>
+                app:ccp_autoFormatNumber="false" />
 
             <android.support.design.widget.TextInputLayout
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="@dimen/value_150dp"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
-                android:hint="@string/mobile" >
+                android:hint="@string/mobile">
 
                 <android.support.design.widget.TextInputEditText
                     android:id="@+id/et_mobile_number"
-                    android:layout_width="@dimen/value_150dp"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:maxLength="@integer/telephone_numbers_max_length_standard"
-                    android:inputType="number" />
+                    android:inputType="number"
+                    android:maxLength="@integer/telephone_numbers_max_length_standard" />
 
             </android.support.design.widget.TextInputLayout>
 
@@ -110,7 +112,7 @@
                 android:layout_height="40dp"
                 android:layout_gravity="right|center_vertical|center_horizontal"
                 android:layout_marginLeft="@dimen/value_10dp"
-                android:background="@drawable/ic_right_arrow"/>
+                android:background="@drawable/ic_right_arrow" />
 
         </LinearLayout>
 
@@ -118,8 +120,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/value_20dp"
-            android:layout_marginRight="@dimen/value_20dp"
             android:layout_marginTop="@dimen/value_10dp"
+            android:layout_marginRight="@dimen/value_20dp"
             android:orientation="horizontal">
 
 
@@ -127,15 +129,15 @@
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="wrap_content"
                 android:layout_height="@dimen/value_48dp"
-                android:hint="@string/otp" >
+                android:hint="@string/otp">
 
                 <android.support.design.widget.TextInputEditText
                     android:id="@+id/et_otp"
                     android:layout_width="@dimen/value_120dp"
-                    android:visibility="gone"
                     android:layout_height="wrap_content"
+                    android:inputType="number"
                     android:maxLength="@integer/telephone_numbers_max_length_standard"
-                    android:inputType="number" />
+                    android:visibility="gone" />
 
             </android.support.design.widget.TextInputLayout>
 
@@ -145,7 +147,7 @@
                 android:layout_height="24dp"
                 android:layout_gravity="center_vertical|center_horizontal"
                 android:layout_marginLeft="@dimen/value_10dp"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
             <TextView
                 android:id="@+id/tv_verifying_otp"
@@ -154,7 +156,7 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginLeft="@dimen/value_10dp"
                 android:text="@string/verifying_otp_please_wait"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
         </LinearLayout>
 

--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -75,8 +75,8 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/value_20dp"
-            android:layout_marginRight="@dimen/value_20dp"
+            android:layout_marginLeft="@dimen/value_10dp"
+            android:layout_marginRight="@dimen/value_10dp"
             android:layout_marginTop="@dimen/value_20dp"
             android:orientation="horizontal">
 
@@ -91,13 +91,13 @@
 
             <android.support.design.widget.TextInputLayout
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="@dimen/value_160dp"
+                android:layout_width="@dimen/value_150dp"
                 android:layout_height="wrap_content"
                 android:hint="@string/mobile" >
 
                 <android.support.design.widget.TextInputEditText
                     android:id="@+id/et_mobile_number"
-                    android:layout_width="@dimen/value_160dp"
+                    android:layout_width="@dimen/value_150dp"
                     android:layout_height="wrap_content"
                     android:maxLength="@integer/telephone_numbers_max_length_standard"
                     android:inputType="number" />


### PR DESCRIPTION
## Issue Fix
Fixes https://github.com/openMF/mobile-wallet/issues/1290

## Screenshot
<img src="https://user-images.githubusercontent.com/73793609/161986114-b5ddc4c9-a8de-4383-b6b8-52fac2da95ea.jpeg" width="250" height="500"/>


## Description
<!--Please Add Summary of what changes you have made.-->
In [activity_mobile_verification.xml](https://github.com/openMF/mobile-wallet/blob/dev/mifospay/src/main/res/layout/activity_mobile_verification.xml) , button to verify phone number is completely visible even for small width screen mobile phones.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
