### PR TITLE
Fixed OTP Layout

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/MainActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/home/ui/MainActivity.java
@@ -10,7 +10,6 @@ import android.support.v4.app.Fragment;
 import android.view.Menu;
 import android.view.MenuItem;
 
-import org.mifos.mobilewallet.core.domain.model.client.Client;
 import org.mifos.mobilewallet.mifospay.R;
 import org.mifos.mobilewallet.mifospay.base.BaseActivity;
 import org.mifos.mobilewallet.mifospay.data.local.LocalRepository;

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/utils/Constants.java
@@ -199,7 +199,8 @@ public class Constants {
     public static final String SI_ID = "standing_instruction_id";
     public static final String UNAUTHORIZED_ERROR = "401 Unauthorized";
 
-    public static final String RECEIPT_SHARING_MESSAGE = "Here's the receipt link for the transaction made using MifosPay from ";
+    public static final String RECEIPT_SHARING_MESSAGE =
+            "Here's the receipt link for the transaction made using MifosPay from ";
     public static final String TO = " to ";
     public static final String COLON = " : ";
 

--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -114,13 +114,13 @@
             <android.support.design.widget.TextInputLayout
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="wrap_content"
-                android:layout_height="@dimen/value_48dp"
+                android:layout_height="wrap_content"
                 android:hint="@string/otp">
 
                 <android.support.design.widget.TextInputEditText
                     android:id="@+id/et_otp"
                     android:layout_width="@dimen/value_120dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="@dimen/value_60dp"
                     android:inputType="number"
                     android:maxLength="@integer/telephone_numbers_max_length_standard"
                     android:visibility="gone"/>


### PR DESCRIPTION
## Issue Fix
Fixes #1355 

## Screenshots
<img src = "https://user-images.githubusercontent.com/91717339/218650779-67ab93a2-87c8-4797-b6d4-adfc240bdbd3.jpg" 
height="500" />

## Description
Increased the height of textinputlayout of otp holder

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

☑ Apply the `AndroidStyle.xml` style template to your code in Android Studio.
☑ Run the unit tests with `./gradlew check` to make sure you didn't break anything
☑ If you have multiple commits please combine them into one commit by squashing them.