### PR TITLE
Fixed OTP Layout

### DIFF
--- a/mifospay/src/main/res/layout/activity_mobile_verification.xml
+++ b/mifospay/src/main/res/layout/activity_mobile_verification.xml
@@ -114,13 +114,13 @@
             <android.support.design.widget.TextInputLayout
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="wrap_content"
-                android:layout_height="@dimen/value_48dp"
+                android:layout_height="wrap_content"
                 android:hint="@string/otp">
 
                 <android.support.design.widget.TextInputEditText
                     android:id="@+id/et_otp"
                     android:layout_width="@dimen/value_120dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="@dimen/value_60dp"
                     android:inputType="number"
                     android:maxLength="@integer/telephone_numbers_max_length_standard"
                     android:visibility="gone"/>


### PR DESCRIPTION
## Issue Fix
Fixes #1355 

## Screenshots
<img src = "https://user-images.githubusercontent.com/91717339/218650779-67ab93a2-87c8-4797-b6d4-adfc240bdbd3.jpg" 
height="500" />

## Description
Increased the height of textinputlayout of otp holder

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

☑ Apply the `AndroidStyle.xml` style template to your code in Android Studio.
☑ Run the unit tests with `./gradlew check` to make sure you didn't break anything
☑ If you have multiple commits please combine them into one commit by squashing them.