### PR TITLE
Restructured input fields in Edit Profile Screen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:8-jdk
+FROM openjdk:11-jdk
 
 ENV GRADLE_HOME /opt/gradle
-ENV GRADLE_VERSION 4.6
+ENV GRADLE_VERSION 6.7.1
 
 RUN set -o errexit -o nounset \
 	&& echo "Downloading Gradle" \

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
@@ -13,7 +13,6 @@ import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.design.widget.BottomSheetDialog;
 import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.TextInputLayout;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.FileProvider;
 import android.text.TextUtils;
@@ -68,18 +67,6 @@ public class EditProfileActivity extends BaseActivity implements
 
     @BindView(R.id.iv_user_image)
     ImageView ivUserImage;
-
-    @BindView(R.id.til_edit_profile_username)
-    TextInputLayout tilUsername;
-
-    @BindView(R.id.til_edit_profile_email)
-    TextInputLayout tilEmail;
-
-    @BindView(R.id.til_edit_profile_vpa)
-    TextInputLayout tilVpa;
-
-    @BindView(R.id.til_edit_profile_mobile)
-    TextInputLayout tilMobileNumber;
 
     @BindView(R.id.et_edit_profile_username)
     EditText etUsername;
@@ -219,25 +206,25 @@ public class EditProfileActivity extends BaseActivity implements
 
     @Override
     public void showUsername(String username) {
-        tilUsername.setHint(username);
+        etUsername.setHint(username);
         handleUpdatedInput(etUsername);
     }
 
     @Override
     public void showEmail(String email) {
-        tilEmail.setHint(email);
+        etEmail.setHint(email);
         handleUpdatedInput(etEmail);
     }
 
     @Override
     public void showVpa(String vpa) {
-        tilVpa.setHint(vpa);
+        etVpa.setHint(vpa);
         handleUpdatedInput(etVpa);
     }
 
     @Override
     public void showMobileNumber(String mobileNumber) {
-        tilMobileNumber.setHint(mobileNumber);
+        etMobileNumber.setHint(mobileNumber);
         handleUpdatedInput(etMobileNumber);
     }
 

--- a/mifospay/src/main/res/layout/activity_edit_profile.xml
+++ b/mifospay/src/main/res/layout/activity_edit_profile.xml
@@ -33,120 +33,126 @@
         android:layout_height="wrap_content" >
 
         <LinearLayout
-                android:orientation="vertical"
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" >
+
+            <include
+                layout="@layout/profile_username_and_image"
+                android:id="@+id/include"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" >
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginTopUserProfile" />
 
-                <include
-                    layout="@layout/profile_username_and_image"
-                    android:id="@+id/include"
+            <TextView
+                android:id="@+id/tv_edit_profile_username"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginItemsInSectionSmall"
+                android:layout_marginLeft="@dimen/marginItemsInSectionExtraSmall"
+                android:text="@string/username"
+                android:textColorHint="@color/colorTextSecondary"
+                android:layout_marginStart="@dimen/marginItemsInSectionExtraSmall" />
+
+            <EditText
+                android:id="@+id/et_edit_profile_username"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/username"
+                android:textColorHint="@color/black"
+                android:inputType="text"
+                app:layout_constraintBaseline_toBaselineOf="@id/tv_edit_profile_username" />
+
+
+            <TextView
+                android:id="@+id/tv_edit_profile_email"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginItemsInSectionSmall"
+                android:layout_marginLeft="@dimen/marginItemsInSectionExtraSmall"
+                android:text="@string/email"
+                android:textColorHint="@color/colorTextSecondary"
+                android:layout_marginStart="@dimen/marginItemsInSectionExtraSmall" />
+
+            <EditText
+                android:id="@+id/et_edit_profile_email"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/email"
+                android:textColorHint="@color/black"
+                android:inputType="textEmailAddress"
+                app:layout_constraintBaseline_toBaselineOf="@id/tv_edit_profile_email" />
+
+            <TextView
+                android:id="@+id/tv_edit_profile_vpa"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginItemsInSectionSmall"
+                android:layout_marginLeft="@dimen/marginItemsInSectionExtraSmall"
+                android:text="@string/vpa"
+                android:textColorHint="@color/colorTextSecondary"
+                android:layout_marginStart="@dimen/marginItemsInSectionExtraSmall" />
+
+            <EditText
+                android:id="@+id/et_edit_profile_vpa"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/vpa"
+                android:textColorHint="@color/black"
+                android:inputType="text"
+                app:layout_constraintBaseline_toBaselineOf="@id/tv_edit_profile_vpa" />
+
+            <TextView
+                android:id="@+id/tv_edit_profile_mobile"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginItemsInSectionSmall"
+                android:layout_marginLeft="@dimen/marginItemsInSectionExtraSmall"
+                android:text="@string/mobile"
+                android:textColorHint="@color/colorTextSecondary"
+                android:layout_marginStart="@dimen/marginItemsInSectionExtraSmall"/>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginItemsInSectionExtraSmall"
+                android:orientation="horizontal">
+
+                <com.hbb20.CountryCodePicker
+                    android:id="@+id/ccp_new_code"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    app:ccp_autoDetectCountry="true"
+                    app:ccp_autoFormatNumber="false" />
+
+                <EditText
+                    android:id="@+id/et_edit_profile_mobile"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/marginTopUserProfile" />
+                    android:hint="@string/mobile"
+                    android:textColorHint="@color/black"
+                    android:inputType="number"/>
 
-                <android.support.design.widget.TextInputLayout
-                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                    android:id="@+id/til_edit_profile_username"
-                    android:layout_marginTop="@dimen/marginItemsInSectionLarge"
-                    android:layout_width="match_parent"
-                    app:helperText="@string/username"
-                    android:hint="@string/username"
-                    android:layout_height="wrap_content" >
-
-                    <android.support.design.widget.TextInputEditText
-                        android:id="@+id/et_edit_profile_username"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:inputType="text"/>
-
-                </android.support.design.widget.TextInputLayout>
-
-                <android.support.design.widget.TextInputLayout
-                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                    android:layout_marginTop="@dimen/marginItemsInSectionMedium"
-                    android:layout_width="match_parent"
-                    android:id="@+id/til_edit_profile_email"
-                    app:layout_anchor="@id/til_edit_profile_username"
-                    app:helperText="@string/email"
-                    android:hint="@string/email"
-                    android:layout_height="wrap_content" >
-
-                    <android.support.design.widget.TextInputEditText
-                        android:id="@+id/et_edit_profile_email"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:inputType="textEmailAddress"/>
-
-                </android.support.design.widget.TextInputLayout>
-
-                <android.support.design.widget.TextInputLayout
-                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                    android:layout_marginTop="@dimen/marginItemsInSectionMedium"
-                    android:id="@+id/til_edit_profile_vpa"
-                    android:layout_width="match_parent"
-                    app:helperText="@string/vpa"
-                    android:hint="@string/vpa"
-                    android:layout_height="wrap_content" >
-
-                    <android.support.design.widget.TextInputEditText
-                        android:id="@+id/et_edit_profile_vpa"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:inputType="text"/>
-
-                </android.support.design.widget.TextInputLayout>
-
-                <LinearLayout
-                    android:layout_marginTop="@dimen/marginItemsInSectionMedium"
-                    android:gravity="center_vertical"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-
-                    <com.hbb20.CountryCodePicker
-                        android:id="@+id/ccp_new_code"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        app:ccp_autoDetectCountry="true"
-                        app:ccp_autoFormatNumber="false" />
-
-                    <android.support.design.widget.TextInputLayout
-                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                        android:id="@+id/til_edit_profile_mobile"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        app:helperText="@string/mobile"
-                        android:hint="@string/mobile" >
-
-                        <android.support.design.widget.TextInputEditText
-                            android:id="@+id/et_edit_profile_mobile"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:maxLength="@integer/telephone_numbers_max_length_standard"
-                            android:inputType="number" />
-
-                    </android.support.design.widget.TextInputLayout>
-
-                </LinearLayout>
-
-                <Button
-                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                    android:text="@string/change_password"
-                    android:id="@+id/btn_change_password"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/marginBetweenSections" />
-
-                <Button
-                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                    android:text="@string/change_passcode"
-                    android:id="@+id/btn_change_passcode"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/marginItemsInSectionExtraSmall"
-                    android:layout_marginBottom="@dimen/paddingLayout" />
             </LinearLayout>
+
+            <Button
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:text="@string/change_password"
+                android:id="@+id/btn_change_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginBetweenSections" />
+
+            <Button
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:text="@string/change_passcode"
+                android:id="@+id/btn_change_passcode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginItemsInSectionSmall"
+                android:layout_marginBottom="@dimen/paddingLayout" />
+        </LinearLayout>
 
     </ScrollView>
 
@@ -164,6 +170,7 @@
         app:layout_anchor="@id/sv_edit_profile"
         android:tint="@color/colorPrimary"
         app:backgroundTint="@color/colorAccentBlack"
-        app:fabSize="normal" />
+        app:fabSize="normal"
+        android:contentDescription="Save Changes" />
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
## Issue Fix
Fixes #1334

## Screenshots
![Screenshot_20230327_233804_Mifos Pay](https://user-images.githubusercontent.com/101107510/228030636-895d69df-f269-42e2-a5b4-0f4062746d5a.jpg)

## Description
<!--Please Add Summary of what changes you have made.-->
Initially, the input fields were set up to display the user's credentials as hints. This was intended to show the user their details when they opened their edit profile screen for the first time. However, as the hints are also associated with the floating labels, the floating text fields were showing the wrong information. The solution was to implement a simple TextView with an EditText to serve the same purpose.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
