### PR TITLE
Fix: Add trim functionality to EditTexts

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/auth/ui/LoginActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/auth/ui/LoginActivity.java
@@ -94,8 +94,8 @@ public class LoginActivity extends BaseActivity implements AuthContract.LoginVie
     }
 
     private void handleLoginInputChanged() {
-        String usernameContent = etUsername.getText().toString();
-        String passwordContent = etPassword.getText().toString();
+        String usernameContent = etUsername.getText().toString().trim();
+        String passwordContent = etPassword.getText().toString().trim();
         mPresenter.handleLoginButtonStatus(usernameContent, passwordContent);
     }
 
@@ -103,8 +103,8 @@ public class LoginActivity extends BaseActivity implements AuthContract.LoginVie
     public void onLoginClicked() {
         Utils.hideSoftKeyboard(this);
         showProgressDialog(Constants.LOGGING_IN);
-        mLoginPresenter.loginUser(etUsername.getText().toString(),
-                etPassword.getText().toString());
+        mLoginPresenter.loginUser(etUsername.getText().toString().trim(),
+                etPassword.getText().toString().trim());
     }
 
     @OnClick(R.id.ll_signup)

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/fragment/DebitCardFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/fragment/DebitCardFragment.java
@@ -121,7 +121,7 @@ public class DebitCardFragment extends BaseFragment implements BankContract.Debi
         showProgressDialog(Constants.PLEASE_WAIT);
 
         mDebitCardPresenter.verifyDebitCard(mEtDebitCardNumber.getText()
-                .toString(), mPeMonth.getText().toString(), mPeYear.getText().toString());
+                .toString().trim(), mPeMonth.getText().toString(), mPeYear.getText().toString());
 
     }
 

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/ui/LinkBankAccountActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/bank/ui/LinkBankAccountActivity.java
@@ -134,7 +134,7 @@ public class LinkBankAccountActivity extends BaseActivity implements
             public void onTextChanged(CharSequence s, int start, int before, int count) {
 //                Log.d("qxz", "onTextChanged: " + s.toString());
 //                mOtherBankAdapter.getFilter().filter(mEtSearchBank.getText().toString());
-                filter(mEtSearchBank.getText().toString());
+                filter(mEtSearchBank.getText().toString().trim());
             }
 
             @Override

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/common/ui/SearchActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/common/ui/SearchActivity.java
@@ -68,9 +68,9 @@ public class SearchActivity extends BaseActivity implements SearchContract.Searc
 
     @OnTextChanged(R.id.et_search)
     public void searchTextChanged() {
-        if (etSearch.getText().toString().length() > 3) {
+        if (etSearch.getText().toString().trim().length() > 3) {
             showSwipeProgress();
-            mSearchPresenter.performSearch(etSearch.getText().toString());
+            mSearchPresenter.performSearch(etSearch.getText().toString().trim());
         } else {
             searchAdapter.clearData();
         }

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/editprofile/ui/EditProfileActivity.java
@@ -149,7 +149,7 @@ public class EditProfileActivity extends BaseActivity implements
     public void onSaveChangesClicked() {
         for (EditText input : userDetailsInputs) {
             if (isDataSaveNecessary(input)) {
-                mPresenter.updateInputById(input.getId(), input.getText().toString());
+                mPresenter.updateInputById(input.getId(), input.getText().toString().trim());
             }
         }
         hideFab();
@@ -191,8 +191,8 @@ public class EditProfileActivity extends BaseActivity implements
     }
 
     private boolean isDataSaveNecessary(EditText input) {
-        String content = input.getText().toString();
-        String currentContent = input.getHint().toString();
+        String content = input.getText().toString().trim();
+        String currentContent = input.getHint().toString().trim();
         return !(TextUtils.isEmpty(content) || content.equals(currentContent));
     }
 

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/kyc/ui/KYCLevel1Fragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/kyc/ui/KYCLevel1Fragment.java
@@ -131,12 +131,12 @@ public class KYCLevel1Fragment extends BaseFragment implements KYCContract.KYCLe
     public void onClickSubmit() {
         showProgressDialog(Constants.PLEASE_WAIT);
 
-        String fname = etFname.getText().toString();
-        String lname = etLname.getText().toString();
-        String address1 = etAddress1.getText().toString();
-        String address2 = etAddress2.getText().toString();
+        String fname = etFname.getText().toString().trim();
+        String lname = etLname.getText().toString().trim();
+        String address1 = etAddress1.getText().toString().trim();
+        String address2 = etAddress2.getText().toString().trim();
         String phoneno = ccpPhonecode.getFullNumber();
-        String dob = etDOB.getText().toString();
+        String dob = etDOB.getText().toString().trim();
 
         mKYCLevel1Presenter.submitData(fname, lname, address1, address2, phoneno, dob);
         Utils.hideSoftKeyboard(getActivity());

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/kyc/ui/KYCLevel2Fragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/kyc/ui/KYCLevel2Fragment.java
@@ -106,7 +106,7 @@ public class KYCLevel2Fragment extends BaseFragment implements KYCContract.KYCLe
     @OnClick(R.id.btn_submit)
     public void onSubmitClicked() {
         showProgressDialog(Constants.PLEASE_WAIT);
-        mKYCLevel2Presenter.uploadKYCDocs(etIdname.getText().toString());
+        mKYCLevel2Presenter.uploadKYCDocs(etIdname.getText().toString().trim());
     }
 
     @Override

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/merchants/ui/MerchantsFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/merchants/ui/MerchantsFragment.java
@@ -196,7 +196,7 @@ public class MerchantsFragment extends BaseFragment implements MerchantsContract
 
     @OnTextChanged(R.id.et_search_merchant)
     void filerMerchants() {
-        filterList(etMerchantSearch.getText().toString());
+        filterList(etMerchantSearch.getText().toString().trim());
     }
 
     public void filterList(String text) {

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/payments/ui/SendFragment.java
@@ -213,12 +213,12 @@ public class SendFragment extends BaseFragment implements BaseHomeContract.Trans
                 etVpa.setText(qrDataArray[0]);
                 etAmount.setText(qrDataArray[1]);
             }
-            String externalId = etVpa.getText().toString();
+            String externalId = etVpa.getText().toString().trim();
             if (etAmount.getText().toString().isEmpty()) {
                 showSnackbar(Constants.PLEASE_ENTER_AMOUNT);
                 return;
             }
-            double amount = Double.parseDouble(etAmount.getText().toString());
+            double amount = Double.parseDouble(etAmount.getText().toString().toString());
             if (!mTransferPresenter.checkSelfTransfer(externalId)) {
                 mTransferPresenter.checkBalanceAvailability(externalId, amount);
             } else {

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/qr/ui/ShowQrActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/qr/ui/ShowQrActivity.java
@@ -159,7 +159,7 @@ public class ShowQrActivity extends BaseActivity implements QrContract.ShowQrVie
         editTextDialog.setPositiveButton(R.string.confirm, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                String amount = edittext.getText().toString();
+                String amount = edittext.getText().toString().trim();
                 if (amount.equals("")) {
                     showToast(getString(R.string.enter_amount));
                     return;

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/receipt/ui/ReceiptActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/receipt/ui/ReceiptActivity.java
@@ -112,7 +112,7 @@ public class ReceiptActivity extends BaseActivity implements ReceiptContract.Rec
                     + Constants.TO
                     + tvTransToName.getText()
                     + Constants.COLON
-                    + tvReceiptLink.getText().toString();
+                    + tvReceiptLink.getText().toString().trim();
         }
     }
 
@@ -205,7 +205,7 @@ public class ReceiptActivity extends BaseActivity implements ReceiptContract.Rec
         ClipboardManager cm = (ClipboardManager) getSystemService(
                 Context.CLIPBOARD_SERVICE);
         ClipData clipData = ClipData.newPlainText(Constants.UNIQUE_RECEIPT_LINK,
-                tvReceiptLink.getText().toString());
+                tvReceiptLink.getText().toString().trim());
         cm.setPrimaryClip(clipData);
         showSnackbar(Constants.UNIQUE_RECEIPT_LINK_COPIED_TO_CLIPBOARD);
     }

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/MobileVerificationActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/MobileVerificationActivity.java
@@ -79,7 +79,7 @@ public class MobileVerificationActivity extends BaseActivity implements
                 @Override
                 public void run() {
                     mMobileVerificationPresenter.requestOTPfromServer(mCcpCode.getFullNumber(),
-                            mEtMobileNumber.getText().toString());
+                            mEtMobileNumber.getText().toString().trim());
                 }
             }, 1500);
 
@@ -123,7 +123,7 @@ public class MobileVerificationActivity extends BaseActivity implements
         handler.postDelayed(new Runnable() {
             @Override
             public void run() {
-                mMobileVerificationPresenter.verifyOTP(mEtOtp.getText().toString());
+                mMobileVerificationPresenter.verifyOTP(mEtOtp.getText().toString().trim());
             }
         }, 1500);
     }

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/SignupActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/SignupActivity.java
@@ -229,15 +229,15 @@ public class SignupActivity extends BaseActivity implements RegistrationContract
             return;
         }
 
-        String firstName = mEtFirstName.getText().toString();
-        String lastName = mEtLastName.getText().toString();
-        String email = mEtEmail.getText().toString();
-        String businessName = mEtBusinessShopName.getText().toString();
-        String addressline1 = mEtAddressLine1.getText().toString();
-        String addressline2 = mEtAddressLine2.getText().toString();
-        String pincode = mEtPinCode.getText().toString();
-        String city = mEtCity.getText().toString();
-        String username = mEtUserName.getText().toString();
+        String firstName = mEtFirstName.getText().toString().trim();
+        String lastName = mEtLastName.getText().toString().trim();
+        String email = mEtEmail.getText().toString().trim();
+        String businessName = mEtBusinessShopName.getText().toString().trim();
+        String addressline1 = mEtAddressLine1.getText().toString().trim();
+        String addressline2 = mEtAddressLine2.getText().toString().trim();
+        String pincode = mEtPinCode.getText().toString().trim();
+        String city = mEtCity.getText().toString().trim();
+        String username = mEtUserName.getText().toString().trim();
         String password = mEtPassword.getText().toString();
         String confirmPassword = mEtConfirmPassword.getText().toString();
 

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/ui/AddCardDialog.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/ui/AddCardDialog.java
@@ -153,9 +153,9 @@ public class AddCardDialog extends BottomSheetDialogFragment {
         if (!areFieldsValid()) {
             return;
         }
-        Card card = new Card(etCardNumber.getText().toString(), etCVV.getText().toString(),
+        Card card = new Card(etCardNumber.getText().toString().trim(), etCVV.getText().toString(),
                 spnMM.getSelectedItem() + "/" + spnYY.getSelectedItem(),
-                etFname.getText().toString(), etLname.getText().toString());
+                etFname.getText().toString().trim(), etLname.getText().toString().trim());
 
         if (forEdit) {
             card.setId(editCard.getId());

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/ui/CardsFragment.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/savedcards/ui/CardsFragment.java
@@ -274,7 +274,7 @@ public class CardsFragment extends BaseFragment implements CardsContract.CardsVi
 
     @OnTextChanged(R.id.et_search_cards)
     void filterCards() {
-        String text = etCardSearch.getText().toString();
+        String text = etCardSearch.getText().toString().trim();
         List<Card> filteredList = new ArrayList<>();
 
         if (cardsList  != null) {


### PR DESCRIPTION
## Issue Fix
Fixes #423 

## Description
<!--Please Add Summary of what changes you have made.-->
Found and added the `trim()` function to all instances of EditTexts with the edge case of breaking if the user inputs a String with leading or trailing spaces. The only exceptions to this were password-related EditTexts & already-defined TextViews because I don't believe we should manipulate the user's inputted password.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
