### PR TITLE
Type: fix

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/MobileVerificationActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/MobileVerificationActivity.java
@@ -114,6 +114,7 @@ public class MobileVerificationActivity extends BaseActivity implements
 
         if (mEtOtp.getText().toString().trim().isEmpty()) {
             showToast("OTP not Entered");
+            mEtOtp.requestFocus();
         } else {
             mFabNext.setClickable(false);
             mProgressBar.setVisibility(View.VISIBLE);

--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/MobileVerificationActivity.java
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/registration/ui/MobileVerificationActivity.java
@@ -112,20 +112,24 @@ public class MobileVerificationActivity extends BaseActivity implements
     public void onNextClicked() {
         Utils.hideSoftKeyboard(this);
 
-        mFabNext.setClickable(false);
-        mProgressBar.setVisibility(View.VISIBLE);
-        mTvVerifyingOtp.setVisibility(View.VISIBLE);
-        mEtOtp.setClickable(false);
-        mEtOtp.setFocusableInTouchMode(false);
-        mEtOtp.setFocusable(false);
+        if (mEtOtp.getText().toString().trim().isEmpty()) {
+            showToast("OTP not Entered");
+        } else {
+            mFabNext.setClickable(false);
+            mProgressBar.setVisibility(View.VISIBLE);
+            mTvVerifyingOtp.setVisibility(View.VISIBLE);
+            mEtOtp.setClickable(false);
+            mEtOtp.setFocusableInTouchMode(false);
+            mEtOtp.setFocusable(false);
 
-        Handler handler = new Handler();
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                mMobileVerificationPresenter.verifyOTP(mEtOtp.getText().toString().trim());
-            }
-        }, 1500);
+            Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mMobileVerificationPresenter.verifyOTP(mEtOtp.getText().toString().trim());
+                }
+            }, 1500);
+        }
     }
 
     @Override


### PR DESCRIPTION
Subject: Fixed issue #1368 change in MobileVerificationActivity
Body: When the user clicks on the fab_next button it was verifying the empty OTP without checking user has entered the OTP in the Edit Text or not and navigating to the next page.
## Issue Fix
Fixes #1368

## Screenshots
![WhatsApp Image 2023-10-05 at 02 35 14_73d4a07a](https://github.com/openMF/mobile-wallet/assets/130087140/ac603edf-bf12-45c1-b2ff-15998b406238)

## Description
I have added an if statement followed by ab else block the if statement checks whether the user has entered the OTP or it is empty if not then it displays a toast message when user tries to verify navigate to the next page.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
