### PR TITLE
Fix: Crash on opening faq section

### DIFF
--- a/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/faq/ui/FAQActivity.kt
+++ b/mifospay/src/main/java/org/mifos/mobilewallet/mifospay/faq/ui/FAQActivity.kt
@@ -2,6 +2,7 @@ package org.mifos.mobilewallet.mifospay.faq.ui
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import dagger.hilt.android.AndroidEntryPoint
 import org.mifos.mobilewallet.mifospay.base.BaseActivity
 import org.mifos.mobilewallet.mifospay.theme.MifosTheme
 
@@ -12,6 +13,8 @@ import org.mifos.mobilewallet.mifospay.theme.MifosTheme
  * @since 11/July/2018
  */
 
+
+@AndroidEntryPoint
 class FAQActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Issue Fix
Fixes #1555 

## Screenshots

https://github.com/openMF/mobile-wallet/assets/91717339/eb666e02-9403-4c64-aa4b-c95226828376


## Description
Added @AddedEntryPoint annotation to FAQActivity Class since it is throwing error FAQActivity does not implement interface dagger.hilt.internal.GeneratedComponent

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.
