### PR TITLE
Feature: Added a MifosDialogBox when the user presses the back arrow …

### DIFF
--- a/core/designsystem/src/main/kotlin/org/mifospay/core/designsystem/component/AlertDialog.kt
+++ b/core/designsystem/src/main/kotlin/org/mifospay/core/designsystem/component/AlertDialog.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.window.Dialog
 
 @Composable
 fun MifosDialogBox(
-    showDialogState: MutableState<Boolean>,
+    showDialogState: Boolean,
     onDismiss: () -> Unit,
     title: Int,
     message: Int? = null,
@@ -18,7 +18,7 @@ fun MifosDialogBox(
     onConfirm: () -> Unit,
     dismissButtonText: Int
 ) {
-    if (showDialogState.value) {
+    if (showDialogState) {
         AlertDialog(
             onDismissRequest = onDismiss,
             title = { Text(text = stringResource(id = title)) },

--- a/core/designsystem/src/main/kotlin/org/mifospay/core/designsystem/component/PermissionBox.kt
+++ b/core/designsystem/src/main/kotlin/org/mifospay/core/designsystem/component/PermissionBox.kt
@@ -115,7 +115,7 @@ fun PermissionBox(
 
     if (shouldShowPermissionRationale) {
         MifosDialogBox(
-            showDialogState = rememberSaveable { mutableStateOf(shouldShowPermissionRationale) },
+            showDialogState =  shouldShowPermissionRationale,
             onDismiss = { shouldShowPermissionRationale = false },
             title = title,
             message = description,

--- a/mifospay/src/main/java/org/mifospay/editprofile/ui/EditProfileScreen.kt
+++ b/mifospay/src/main/java/org/mifospay/editprofile/ui/EditProfileScreen.kt
@@ -112,14 +112,14 @@ fun EditProfileScreen(
     updateSuccess: Boolean,
     uri: Uri?
 ) {
-    val showDiscardChangesDialog = rememberSaveable { mutableStateOf(false) }
+    var showDiscardChangesDialog by rememberSaveable { mutableStateOf(false) }
     Box(
         modifier = Modifier
             .fillMaxSize()
     ) {
         MifosScaffold(
             topBarTitle = R.string.edit_profile,
-            backPress = { showDiscardChangesDialog.value = true },
+            backPress = { showDiscardChangesDialog = true },
             scaffoldContent = {
                 when (editProfileUiState) {
                     EditProfileUiState.Loading -> {
@@ -153,11 +153,11 @@ fun EditProfileScreen(
 
         MifosDialogBox(
             showDialogState = showDiscardChangesDialog,
-            onDismiss = { showDiscardChangesDialog.value = false },
+            onDismiss = { showDiscardChangesDialog = false },
             title = R.string.discard_changes,
             confirmButtonText = R.string.confirm_text,
             onConfirm = {
-                showDiscardChangesDialog.value = false
+                showDiscardChangesDialog = false
                 onBackClick.invoke()
             },
             dismissButtonText = R.string.dismiss_text

--- a/mifospay/src/main/java/org/mifospay/editprofile/ui/EditProfileScreen.kt
+++ b/mifospay/src/main/java/org/mifospay/editprofile/ui/EditProfileScreen.kt
@@ -53,6 +53,7 @@ import org.mifospay.R
 import org.mifospay.core.designsystem.component.MfLoadingWheel
 import org.mifospay.core.designsystem.component.MfOutlinedTextField
 import org.mifospay.core.designsystem.component.MifosBottomSheet
+import org.mifospay.core.designsystem.component.MifosDialogBox
 import org.mifospay.core.designsystem.component.MifosScaffold
 import org.mifospay.core.designsystem.component.PermissionBox
 import org.mifospay.core.designsystem.icon.MifosIcons.Camera
@@ -111,13 +112,14 @@ fun EditProfileScreen(
     updateSuccess: Boolean,
     uri: Uri?
 ) {
+    val showDialog = rememberSaveable { mutableStateOf(false) }
     Box(
         modifier = Modifier
             .fillMaxSize()
     ) {
         MifosScaffold(
             topBarTitle = R.string.edit_profile,
-            backPress = { onBackClick.invoke() },
+            backPress = { showDialog.value = true },
             scaffoldContent = {
                 when (editProfileUiState) {
                     EditProfileUiState.Loading -> {
@@ -148,6 +150,18 @@ fun EditProfileScreen(
                     }
                 }
             })
+
+        MifosDialogBox(
+            showDialogState = showDialog,
+            onDismiss = { showDialog.value = false },
+            title = R.string.discard_changes,
+            confirmButtonText = R.string.confirm_text,
+            onConfirm = {
+                showDialog.value = false
+                onBackClick.invoke()
+            },
+            dismissButtonText = R.string.dismiss_text
+        )
     }
 }
 

--- a/mifospay/src/main/java/org/mifospay/editprofile/ui/EditProfileScreen.kt
+++ b/mifospay/src/main/java/org/mifospay/editprofile/ui/EditProfileScreen.kt
@@ -112,14 +112,14 @@ fun EditProfileScreen(
     updateSuccess: Boolean,
     uri: Uri?
 ) {
-    val showDialog = rememberSaveable { mutableStateOf(false) }
+    val showDiscardChangesDialog = rememberSaveable { mutableStateOf(false) }
     Box(
         modifier = Modifier
             .fillMaxSize()
     ) {
         MifosScaffold(
             topBarTitle = R.string.edit_profile,
-            backPress = { showDialog.value = true },
+            backPress = { showDiscardChangesDialog.value = true },
             scaffoldContent = {
                 when (editProfileUiState) {
                     EditProfileUiState.Loading -> {
@@ -152,12 +152,12 @@ fun EditProfileScreen(
             })
 
         MifosDialogBox(
-            showDialogState = showDialog,
-            onDismiss = { showDialog.value = false },
+            showDialogState = showDiscardChangesDialog,
+            onDismiss = { showDiscardChangesDialog.value = false },
             title = R.string.discard_changes,
             confirmButtonText = R.string.confirm_text,
             onConfirm = {
-                showDialog.value = false
+                showDiscardChangesDialog.value = false
                 onBackClick.invoke()
             },
             dismissButtonText = R.string.dismiss_text

--- a/mifospay/src/main/java/org/mifospay/savedcards/ui/CardsScreen.kt
+++ b/mifospay/src/main/java/org/mifospay/savedcards/ui/CardsScreen.kt
@@ -65,7 +65,7 @@ fun CardsScreen(
     val cardListUiState by viewModel.cardListUiState.collectAsStateWithLifecycle()
 
     var showCardBottomSheet by rememberSaveable { mutableStateOf(false) }
-    val showConfirmDeleteDialog = rememberSaveable { mutableStateOf(false) }
+    var showConfirmDeleteDialog by rememberSaveable { mutableStateOf(false) }
 
     var deleteCardID by rememberSaveable { mutableStateOf<Int?>(null) }
 
@@ -87,12 +87,12 @@ fun CardsScreen(
 
     MifosDialogBox(
         showDialogState = showConfirmDeleteDialog,
-        onDismiss = { showConfirmDeleteDialog.value = false },
+        onDismiss = { showConfirmDeleteDialog = false },
         title = R.string.delete_card,
         confirmButtonText = R.string.yes,
         onConfirm = {
             deleteCardID?.let { viewModel.deleteCard(it) }
-            showConfirmDeleteDialog.value = false
+            showConfirmDeleteDialog = false
         },
         dismissButtonText = R.string.no,
         message = R.string.confirm_delete_card
@@ -103,7 +103,7 @@ fun CardsScreen(
         cardListUiState = cardListUiState,
         onEditCard = onEditCard,
         onDeleteCard = {
-            showConfirmDeleteDialog.value = true
+            showConfirmDeleteDialog = true
             deleteCardID = it.id
         },
         onAddBtn = { showCardBottomSheet = true },

--- a/mifospay/src/main/java/org/mifospay/settings/ui/DialogManager.kt
+++ b/mifospay/src/main/java/org/mifospay/settings/ui/DialogManager.kt
@@ -12,7 +12,7 @@ import org.mifospay.core.ui.utility.DialogType
 fun DialogManager(dialogState: DialogState, onDismiss: () -> Unit) {
     when (dialogState.type) {
         DialogType.DISABLE_ACCOUNT -> MifosDialogBox(
-            showDialogState = remember { mutableStateOf(true) },
+            showDialogState = true,
             title = R.string.alert_disable_account,
             message = R.string.alert_disable_account_desc,
             confirmButtonText = R.string.ok,
@@ -22,7 +22,7 @@ fun DialogManager(dialogState: DialogState, onDismiss: () -> Unit) {
         )
 
         DialogType.LOGOUT -> MifosDialogBox(
-            showDialogState = remember { mutableStateOf(true) },
+            showDialogState =true,
             title = R.string.log_out_title,
             message = R.string.empty,
             confirmButtonText = R.string.yes,

--- a/mifospay/src/main/res/values/strings.xml
+++ b/mifospay/src/main/res/values/strings.xml
@@ -412,5 +412,7 @@
     <string name="invoice">Invoice</string>
     <string name="failed_to_save_changes">Failed To Save Changes</string>
     <string name="back">Back</string>
-
+    <string name="discard_changes">Do you want to discard changes?</string>
+    <string name="dismiss_text">Cancel</string>
+    <string name="confirm_text">Discard</string>
 </resources>


### PR DESCRIPTION
…in the EditProfileScreen.kt

 Description
 When a user clicks on the back arrow the activity is finished without any alert dialog. I have added the MifosDialogBox for this purpose

## Video

Before

https://github.com/openMF/mobile-wallet/assets/130087140/abb212fb-1375-4cd4-b26f-0825dfe9fd7d

After

https://github.com/openMF/mobile-wallet/assets/130087140/c79f2ebb-6d6f-46dc-89c2-68d9d9c97afa



## Description
I have added a MifosDialogBox to the EditProfileScreen.kt such that whenever user clicks on the back arrow it will alert the user whether the changes made are to be discarded or not.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
