### PR TITLE
Fix: App crashing when clicked on share button to share the QR code o…

### DIFF
--- a/mifospay/src/main/java/org/mifospay/utils/ImageUtils.kt
+++ b/mifospay/src/main/java/org/mifospay/utils/ImageUtils.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.net.Uri
 import androidx.core.content.FileProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
+import org.mifospay.BuildConfig
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -22,7 +23,7 @@ object ImageUtils {
             stream.close()
             uri = FileProvider.getUriForFile(
                 context,
-                "org.mifospay.provider", file
+                BuildConfig.APPLICATION_ID + ".provider", file
             )
         } catch (e: IOException) {
             e.printStackTrace()


### PR DESCRIPTION
…f the user.

Description:
The ImageUtils.kt file was not using the correct APPLICATION_ID which was causing the IllegalArgumentException for the provider. I have corrected the code using the correct APPLICATION_ID.

## Video
Before:

https://github.com/openMF/mobile-wallet/assets/130087140/4f460c7e-615d-4376-a087-f8cdb7a4e91a

After:

https://github.com/openMF/mobile-wallet/assets/130087140/87bcc3d4-4fc2-481b-8baa-a3e8159f6dc4



## Description
I have just used the correct APPLICATION_ID for the provider to work properly.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
