### PR TITLE
Fix: Explicitly pass secrets to reusable workflows

### DIFF
--- a/.github/workflows/multi-platform-build-and-publish.yml
+++ b/.github/workflows/multi-platform-build-and-publish.yml
@@ -114,7 +114,6 @@ jobs:
   multi_platform_build_and_publish:
     name: Multi-Platform Build and Publish
     uses: openMF/mifos-mobile-github-actions/.github/workflows/multi-platform-build-and-publish.yaml@main
-    secrets: inherit
     with:
       release_type: ${{ inputs.release_type }}
       target_branch: ${{ inputs.target_branch }}
@@ -127,3 +126,34 @@ jobs:
       publish_ios: ${{ inputs.publish_ios }}
       publish_desktop: ${{ inputs.publish_desktop }}
       publish_web: ${{ inputs.publish_web }}
+    secrets:
+      original_keystore_file: ${{ secrets.ORIGINAL_KEYSTORE_FILE }}
+      original_keystore_file_password: ${{ secrets.ORIGINAL_KEYSTORE_FILE_PASSWORD }}
+      original_keystore_alias: ${{ secrets.ORIGINAL_KEYSTORE_ALIAS }}
+      original_keystore_alias_password: ${{ secrets.ORIGINAL_KEYSTORE_ALIAS_PASSWORD }}
+
+      upload_keystore_file: ${{ secrets.UPLOAD_KEYSTORE_FILE }}
+      upload_keystore_file_password: ${{ secrets.UPLOAD_KEYSTORE_FILE_PASSWORD }}
+      upload_keystore_alias: ${{ secrets.UPLOAD_KEYSTORE_ALIAS }}
+      upload_keystore_alias_password: ${{ secrets.UPLOAD_KEYSTORE_ALIAS_PASSWORD }}
+
+      notarization_apple_id: ${{ secrets.NOTARIZATION_APPLE_ID }}
+      notarization_password: ${{ secrets.NOTARIZATION_PASSWORD }}
+      notarization_team_id: ${{ secrets.NOTARIZATION_TEAM_ID }}
+
+      windows_signing_key: ${{ secrets.WINDOWS_SIGNING_KEY }}
+      windows_signing_password: ${{ secrets.WINDOWS_SIGNING_PASSWORD }}
+      windows_signing_certificate: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE }}
+
+      macos_signing_key: ${{ secrets.MACOS_SIGNING_KEY }}
+      macos_signing_password: ${{ secrets.MACOS_SIGNING_PASSWORD }}
+      macos_signing_certificate: ${{ secrets.MACOS_SIGNING_CERTIFICATE }}
+
+      linux_signing_key: ${{ secrets.LINUX_SIGNING_KEY }}
+      linux_signing_password: ${{ secrets.LINUX_SIGNING_PASSWORD }}
+      linux_signing_certificate: ${{ secrets.LINUX_SIGNING_CERTIFICATE }}
+
+      google_services: ${{ secrets.GOOGLESERVICES }}
+      firebase_creds: ${{ secrets.FIREBASECREDS }}
+      playstore_creds: ${{ secrets.PLAYSTORECREDS }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -78,6 +78,7 @@ jobs:
     name: Promote Beta to Production Play Store
     uses: openMF/mifos-mobile-github-actions/.github/workflows/promote-to-production.yaml@main
     if: ${{ inputs.publish_to_play_store == true }}
-    secrets: inherit
+    secrets:
+      playstore_creds: ${{ secrets.PLAYSTORECREDS }}
     with:
       android_package_name: 'mifospay-android'


### PR DESCRIPTION
This commit explicitly passes secrets to reusable workflows, rather than relying on inheritance. This addresses an issue with reusable workflows not inheriting secrets as expected.
- The `secrets: inherit` statement has been removed from the `multi-platform-build-and-publish` and `promote-to-production` workflows.
- Instead, secrets are explicitly defined in the `secrets` section of each workflow, ensuring that the reusable workflows have access to the necessary secrets.

## Issue Fix
Fixes #{Issue Number}
Jira Task: [Task_Number](Task_Link)

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->

## Description
<!--Please Add Summary of what changes you have made.-->

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.
