### PR TITLE
Fix Client and Merchant registration error

### DIFF
--- a/core/common/src/commonMain/kotlin/org/mifospay/core/common/utils/StringExtensions.kt
+++ b/core/common/src/commonMain/kotlin/org/mifospay/core/common/utils/StringExtensions.kt
@@ -31,3 +31,11 @@ fun maskString(input: String, maskChar: Char = '*'): String {
 fun String.capitalizeWords(): String = split(" ").joinToString(" ") { it ->
     it.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
 }
+
+fun String.hasSpaces(): Boolean {
+    return this.contains(" ")
+}
+
+fun String.hasConsecutiveRepetitions(): Boolean {
+    return Regex("(.)\\1").containsMatchIn(this)
+}

--- a/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/PasswordStrengthIndicator.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/PasswordStrengthIndicator.kt
@@ -138,7 +138,7 @@ private fun MinimumCharacterCount(
         } else {
             MaterialTheme.colorScheme.surfaceDim
         },
-        label = "minmumCharacterCountColor",
+        label = "minimumCharacterCountColor",
     )
     Row(
         modifier = modifier,

--- a/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/utils/PasswordChecker.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/utils/PasswordChecker.kt
@@ -9,6 +9,8 @@
  */
 package org.mifospay.core.ui.utils
 
+import org.mifospay.core.common.utils.hasConsecutiveRepetitions
+import org.mifospay.core.common.utils.hasSpaces
 import kotlin.math.log2
 import kotlin.math.pow
 
@@ -19,27 +21,20 @@ object PasswordChecker {
     private const val MAX_PASSWORD_LENGTH = 50
 
     fun getPasswordStrengthResult(password: String): PasswordStrengthResult {
-        when {
-            password.isEmpty() -> return PasswordStrengthResult.Error("Password cannot be empty.")
-            password.length > MAX_PASSWORD_LENGTH -> {
-                return PasswordStrengthResult.Error(
-                    "Password is too long. Maximum length is $MAX_PASSWORD_LENGTH characters.",
-                )
-            }
-            hasSpaceOrConsecutiveRepetitions(password) -> {
-                return PasswordStrengthResult.Error(
-                    "Password must not contain spaces or repeating characters.",
-                )
-            }
+        val errors = buildList {
+            if (password.isEmpty()) add("- Password cannot be empty.")
+            if (password.length > MAX_PASSWORD_LENGTH) add("- Password is too long. Maximum length is $MAX_PASSWORD_LENGTH characters.")
+            if (password.hasSpaces()) add("- Password must not contain spaces.")
+            if (password.hasConsecutiveRepetitions()) add("- Password must not contain consecutive repetitive characters.")
+        }
+
+        if (errors.isNotEmpty()) {
+            return PasswordStrengthResult.Error(errors.joinToString("\n"))
         }
 
         val result = getPasswordStrength(password)
 
         return PasswordStrengthResult.Success(result)
-    }
-
-    fun hasSpaceOrConsecutiveRepetitions(password: String): Boolean {
-        return Regex("(.)\\1").containsMatchIn(password) || password.contains(" ")
     }
 
     private fun getPasswordStrength(password: String): PasswordStrength {
@@ -91,10 +86,10 @@ object PasswordChecker {
         if (password.length < STRONG_PASSWORD_LENGTH) {
             feedback.add("For a stronger password, use at least $STRONG_PASSWORD_LENGTH characters.")
         }
-        if (Regex("(.)\\1").containsMatchIn(password)) {
+        if (password.hasConsecutiveRepetitions()) {
             feedback.add("Remove consecutive repeating characters.")
         }
-        if (password.contains(" ")) {
+        if (password.hasSpaces()) {
             feedback.add("Remove spaces.")
         }
 

--- a/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/utils/PasswordChecker.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/utils/PasswordChecker.kt
@@ -22,10 +22,10 @@ object PasswordChecker {
 
     fun getPasswordStrengthResult(password: String): PasswordStrengthResult {
         val errors = buildList {
-            if (password.isEmpty()) add("- Password cannot be empty.")
-            if (password.length > MAX_PASSWORD_LENGTH) add("- Password is too long. Maximum length is $MAX_PASSWORD_LENGTH characters.")
-            if (password.hasSpaces()) add("- Password must not contain spaces.")
-            if (password.hasConsecutiveRepetitions()) add("- Password must not contain consecutive repetitive characters.")
+            if (password.isEmpty()) add("Password cannot be empty.")
+            if (password.length > MAX_PASSWORD_LENGTH) add("Password is too long. Maximum length is $MAX_PASSWORD_LENGTH characters.")
+            if (password.hasSpaces()) add("Password must not contain spaces.")
+            if (password.hasConsecutiveRepetitions()) add("Password must not contain consecutive repetitive characters.")
         }
 
         if (errors.isNotEmpty()) {

--- a/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/utils/PasswordChecker.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/utils/PasswordChecker.kt
@@ -13,10 +13,10 @@ import kotlin.math.log2
 import kotlin.math.pow
 
 object PasswordChecker {
-    private const val MIN_PASSWORD_LENGTH = 8
-    private const val STRONG_PASSWORD_LENGTH = 12
+    private const val MIN_PASSWORD_LENGTH = 12
+    private const val STRONG_PASSWORD_LENGTH = 16
     private const val MIN_ENTROPY_BITS = 60.0
-    private const val MAX_PASSWORD_LENGTH = 128
+    private const val MAX_PASSWORD_LENGTH = 50
 
     fun getPasswordStrengthResult(password: String): PasswordStrengthResult {
         when {
@@ -33,6 +33,10 @@ object PasswordChecker {
         return PasswordStrengthResult.Success(result)
     }
 
+    fun hasSpaceOrConsecutiveRepetitions(password: String): Boolean {
+        return Regex("(.)\\1").containsMatchIn(password) || password.contains(" ")
+    }
+
     fun getPasswordStrength(password: String): PasswordStrength {
         val length = password.length
         val hasUpperCase = password.any { it.isUpperCase() }
@@ -47,12 +51,14 @@ object PasswordChecker {
         return when {
             length < MIN_PASSWORD_LENGTH -> PasswordStrength.LEVEL_0
             numTypesPresent == 1 -> PasswordStrength.LEVEL_1
-            numTypesPresent == 2 -> PasswordStrength.LEVEL_2
-            numTypesPresent == 3 && length >= STRONG_PASSWORD_LENGTH -> PasswordStrength.LEVEL_4
+            numTypesPresent == 2 || numTypesPresent == 3 ||
+                hasSpaceOrConsecutiveRepetitions(password) -> PasswordStrength.LEVEL_2
             numTypesPresent == 4 && length >= STRONG_PASSWORD_LENGTH &&
                 entropyBits >= MIN_ENTROPY_BITS -> PasswordStrength.LEVEL_5
+            numTypesPresent == 4 && length >= STRONG_PASSWORD_LENGTH -> PasswordStrength.LEVEL_4
+            numTypesPresent == 4 && length < STRONG_PASSWORD_LENGTH -> PasswordStrength.LEVEL_3
 
-            else -> PasswordStrength.LEVEL_3
+            else -> PasswordStrength.LEVEL_2
         }
     }
 
@@ -81,6 +87,12 @@ object PasswordChecker {
         }
         if (password.length < STRONG_PASSWORD_LENGTH) {
             feedback.add("For a stronger password, use at least $STRONG_PASSWORD_LENGTH characters.")
+        }
+        if (Regex("(.)\\1").containsMatchIn(password)) {
+            feedback.add("Remove consecutive repeating characters.")
+        }
+        if (password.contains(" ")) {
+            feedback.add("Remove spaces.")
         }
 
         return feedback

--- a/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/utils/PasswordChecker.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifospay/core/ui/utils/PasswordChecker.kt
@@ -14,8 +14,8 @@ import kotlin.math.pow
 
 object PasswordChecker {
     private const val MIN_PASSWORD_LENGTH = 12
-    private const val STRONG_PASSWORD_LENGTH = 16
-    private const val MIN_ENTROPY_BITS = 60.0
+    private const val STRONG_PASSWORD_LENGTH = 15
+    private const val MIN_ENTROPY_BITS = 100.0
     private const val MAX_PASSWORD_LENGTH = 50
 
     fun getPasswordStrengthResult(password: String): PasswordStrengthResult {
@@ -24,6 +24,11 @@ object PasswordChecker {
             password.length > MAX_PASSWORD_LENGTH -> {
                 return PasswordStrengthResult.Error(
                     "Password is too long. Maximum length is $MAX_PASSWORD_LENGTH characters.",
+                )
+            }
+            hasSpaceOrConsecutiveRepetitions(password) -> {
+                return PasswordStrengthResult.Error(
+                    "Password must not contain spaces or repeating characters.",
                 )
             }
         }
@@ -37,7 +42,7 @@ object PasswordChecker {
         return Regex("(.)\\1").containsMatchIn(password) || password.contains(" ")
     }
 
-    fun getPasswordStrength(password: String): PasswordStrength {
+    private fun getPasswordStrength(password: String): PasswordStrength {
         val length = password.length
         val hasUpperCase = password.any { it.isUpperCase() }
         val hasLowerCase = password.any { it.isLowerCase() }
@@ -51,14 +56,12 @@ object PasswordChecker {
         return when {
             length < MIN_PASSWORD_LENGTH -> PasswordStrength.LEVEL_0
             numTypesPresent == 1 -> PasswordStrength.LEVEL_1
-            numTypesPresent == 2 || numTypesPresent == 3 ||
-                hasSpaceOrConsecutiveRepetitions(password) -> PasswordStrength.LEVEL_2
+            numTypesPresent == 2 || numTypesPresent == 3 -> PasswordStrength.LEVEL_2
             numTypesPresent == 4 && length >= STRONG_PASSWORD_LENGTH &&
                 entropyBits >= MIN_ENTROPY_BITS -> PasswordStrength.LEVEL_5
             numTypesPresent == 4 && length >= STRONG_PASSWORD_LENGTH -> PasswordStrength.LEVEL_4
-            numTypesPresent == 4 && length < STRONG_PASSWORD_LENGTH -> PasswordStrength.LEVEL_3
 
-            else -> PasswordStrength.LEVEL_2
+            else -> PasswordStrength.LEVEL_3
         }
     }
 

--- a/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/signup/SignupViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/signup/SignupViewModel.kt
@@ -34,7 +34,8 @@ import org.mifospay.core.ui.utils.PasswordStrengthResult
 import org.mifospay.feature.auth.signup.SignUpAction.Internal.ReceivePasswordStrengthResult
 
 private const val KEY_STATE = "signup_state"
-private const val MIN_PASSWORD_LENGTH = 8
+private const val MIN_PASSWORD_LENGTH = 12
+private const val MAX_PASSWORD_LENGTH = 50
 
 class SignupViewModel(
     private val userRepository: UserRepository,
@@ -288,6 +289,16 @@ class SignupViewModel(
             }
         }
 
+        state.passwordInput.length > MAX_PASSWORD_LENGTH -> {
+            mutableStateFlow.update {
+                it.copy(
+                    dialogState = SignUpDialog.Error(
+                        "Password must be less than $MAX_PASSWORD_LENGTH characters long.",
+                    ),
+                )
+            }
+        }
+
         !state.isPasswordMatch -> {
             mutableStateFlow.update {
                 it.copy(dialogState = SignUpDialog.Error("Passwords do not match."))
@@ -296,7 +307,17 @@ class SignupViewModel(
 
         !state.isPasswordStrong -> {
             mutableStateFlow.update {
-                it.copy(dialogState = SignUpDialog.Error("Password is weak."))
+                it.copy(
+                    dialogState = SignUpDialog.Error(
+                        "Please ensure password contains :" +
+                            "\n- At least one uppercase character" +
+                            "\n- At least one lowercase character" +
+                            "\n- At least one numeric digit" +
+                            "\n- At least one special character" +
+                            "\n- No spaces" +
+                            "\n- No consecutive repeating characters",
+                    ),
+                )
             }
         }
 
@@ -347,50 +368,62 @@ class SignupViewModel(
             it.copy(dialogState = SignUpDialog.Loading)
         }
 
-        // 0. Unique Mobile Number (checked in MOBILE VERIFICATION ACTIVITY)
-        // 1. Check for unique external id and username
+        // 1. Check for unique external id, username and mobile no.
         // 2. Create user
         // 3. Create Client
         // 4. Update User and connect client with user
-        checkForUsernameExists(state.userNameInput)
+
+        val fieldsToCheck = listOf(
+            Pair("username", state.userNameInput),
+            Pair("mobileNo", state.mobileNumberInput),
+        )
+        checkUniqueFields(fieldsToCheck)
     }
 
-    private fun checkForUsernameExists(username: String) {
+    private fun checkUniqueFields(fields: List<Pair<String, String>>) {
         viewModelScope.launch {
-            val result = searchRepository.searchResources(
-                username,
-                Constants.CLIENTS,
-                false,
+            val errorMessages = mutableListOf<String>()
+
+            val fieldNamesMap = mapOf(
+                "username" to "Username",
+                "mobileNo" to "Mobile Number",
             )
 
-            when (result) {
-                is DataState.Error -> {
-                    val message = result.exception.message.toString()
-                    mutableStateFlow.update {
-                        it.copy(dialogState = SignUpDialog.Error(message))
+            for ((fieldName, fieldValue) in fields) {
+                val result = searchRepository.searchResources(
+                    fieldValue,
+                    Constants.CLIENTS,
+                    false,
+                )
+
+                when (result) {
+                    is DataState.Error -> {
+                        errorMessages.add(result.exception.message.toString())
                     }
-                }
 
-                is DataState.Success -> {
-                    if (result.data.isEmpty()) {
-                        // Username is unique
-                        val newUser = NewUser(
-                            state.userNameInput,
-                            state.firstNameInput,
-                            state.lastNameInput,
-                            state.emailInput,
-                            state.passwordInput,
-                        )
-
-                        createUser(newUser)
-                    } else {
-                        mutableStateFlow.update {
-                            it.copy(dialogState = SignUpDialog.Error("Username already exists."))
+                    is DataState.Success -> {
+                        if (result.data.isNotEmpty()) { // result contains instances with same Username or Mobile No.
+                            errorMessages.add("${fieldNamesMap[fieldName] ?: fieldName} already exists.")
                         }
                     }
-                }
 
-                is DataState.Loading -> Unit
+                    is DataState.Loading -> Unit
+                }
+            }
+
+            if (errorMessages.isNotEmpty()) {
+                mutableStateFlow.update {
+                    it.copy(dialogState = SignUpDialog.Error(errorMessages.joinToString("\n")))
+                }
+            } else {
+                val newUser = NewUser(
+                    state.userNameInput,
+                    state.firstNameInput,
+                    state.lastNameInput,
+                    state.emailInput,
+                    state.passwordInput,
+                )
+                createUser(newUser)
             }
         }
     }

--- a/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/signup/SignupViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/signup/SignupViewModel.kt
@@ -319,7 +319,7 @@ class SignupViewModel(
                 "\n- At least one numeric digit" +
                 "\n- At least one special character"
             mutableStateFlow.update {
-                it.copy(dialogState = SignUpDialog.Error(errorMessage))
+                it.copy(dialogState = SignUpDialog.Error(errorMessage.lines().joinToString("\n") { "- $it" }))
             }
         }
 

--- a/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/signup/SignupViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/signup/SignupViewModel.kt
@@ -12,6 +12,8 @@ package org.mifospay.feature.auth.signup
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.mifospay.core.common.DataState
@@ -173,7 +175,7 @@ class SignupViewModel(
 
     private fun handlePasswordInput(action: SignUpAction.PasswordInputChange) {
         // Update input:
-        mutableStateFlow.update { it.copy(passwordInput = action.password) }
+        mutableStateFlow.update { it.copy(passwordInput = action.password, passwordError = null) }
         // Update password strength:
         passwordStrengthJob.cancel()
         if (action.password.isEmpty()) {
@@ -204,7 +206,11 @@ class SignupViewModel(
                 }
             }
 
-            is PasswordStrengthResult.Error -> {}
+            is PasswordStrengthResult.Error -> {
+                mutableStateFlow.update {
+                    it.copy(passwordError = result.message.toString(), passwordStrengthState = PasswordStrengthState.NONE)
+                }
+            }
         }
     }
 
@@ -306,18 +312,14 @@ class SignupViewModel(
         }
 
         !state.isPasswordStrong -> {
+            val errorMessage = state.passwordError?.takeIf { it.isNotBlank() }
+                ?: "Please ensure password contains :" +
+                "\n- At least one uppercase character" +
+                "\n- At least one lowercase character" +
+                "\n- At least one numeric digit" +
+                "\n- At least one special character"
             mutableStateFlow.update {
-                it.copy(
-                    dialogState = SignUpDialog.Error(
-                        "Please ensure password contains :" +
-                            "\n- At least one uppercase character" +
-                            "\n- At least one lowercase character" +
-                            "\n- At least one numeric digit" +
-                            "\n- At least one special character" +
-                            "\n- No spaces" +
-                            "\n- No consecutive repeating characters",
-                    ),
-                )
+                it.copy(dialogState = SignUpDialog.Error(errorMessage))
             }
         }
 
@@ -368,46 +370,31 @@ class SignupViewModel(
             it.copy(dialogState = SignUpDialog.Loading)
         }
 
-        // 1. Check for unique external id, username and mobile no.
-        // 2. Create user
-        // 3. Create Client
-        // 4. Update User and connect client with user
-
-        val fieldsToCheck = listOf(
-            Pair("username", state.userNameInput),
-            Pair("mobileNo", state.mobileNumberInput),
+        val fieldsToCheck = mapOf(
+            "Username" to state.userNameInput,
+            "Mobile Number" to state.mobileNumberInput,
         )
         checkUniqueFields(fieldsToCheck)
     }
 
-    private fun checkUniqueFields(fields: List<Pair<String, String>>) {
+    private fun checkUniqueFields(fields: Map<String, String>) {
         viewModelScope.launch {
-            val errorMessages = mutableListOf<String>()
+            val results = fields.map { (label, value) ->
+                async {
+                    val result = searchRepository.searchResources(value, Constants.CLIENTS, false)
+                    label to result
+                }
+            }.awaitAll()
 
-            val fieldNamesMap = mapOf(
-                "username" to "Username",
-                "mobileNo" to "Mobile Number",
-            )
-
-            for ((fieldName, fieldValue) in fields) {
-                val result = searchRepository.searchResources(
-                    fieldValue,
-                    Constants.CLIENTS,
-                    false,
-                )
-
+            val errorMessages = results.mapNotNull { (label, result) ->
                 when (result) {
-                    is DataState.Error -> {
-                        errorMessages.add(result.exception.message.toString())
-                    }
-
                     is DataState.Success -> {
-                        if (result.data.isNotEmpty()) { // result contains instances with same Username or Mobile No.
-                            errorMessages.add("${fieldNamesMap[fieldName] ?: fieldName} already exists.")
-                        }
+                        if (result.data.isNotEmpty()) "$label already exists." else null
                     }
-
-                    is DataState.Loading -> Unit
+                    is DataState.Error ->
+                        result.exception.message
+                            ?: "Error checking $label."
+                    else -> null
                 }
             }
 
@@ -542,6 +529,7 @@ data class SignUpState(
     val businessNameInput: String = "",
     val dialogState: SignUpDialog? = null,
     val passwordStrengthState: PasswordStrengthState = PasswordStrengthState.NONE,
+    val passwordError: String? = null,
 ) : Parcelable {
     @IgnoredOnParcel
     val isPasswordStrong: Boolean


### PR DESCRIPTION
## Issue Fix
Fixes MW-219 Issue on client and merchant registration
Jira Task: [219](https://mifosforge.jira.com/browse/MW-219)

## Screenshots
## Screenshots

| Duplicate Mobile No. | Weak Password | Password with space/repititions
|----------------------|---------------|---------------|
| <img src="https://github.com/user-attachments/assets/c6d37f32-90bd-4170-95ec-0696418bcb7e" width="200"/> | <img src="https://github.com/user-attachments/assets/6460d3b6-7f38-4a25-84f7-a77e972418b6" width="200"/> | <img src="https://github.com/user-attachments/assets/cd0ce730-dbc1-451a-b1ac-1eca2b653edf" width="200"/> |


## Description
### Mobile No. 
- HTTP response BODY contained 
    ```{"developerMessage":"The request caused a data integrity issue to be fired by the database.","httpStatusCode":"403","defaultUserMessage":"Client with mobileNo `1234567890` already exists","userMessageGlobalisationCode":"error.msg.client.duplicate.mobileNo","errors":[{"defaultUserMessage":"Client with mobileNo `1234567890` already exists","parameterName":"mobileNo","developerMessage":"Client with mobileNo `1234567890` already exists","userMessageGlobalisationCode":"error.msg.client.duplicate.mobileNo","args":[{"value":"1234567890"}]}]}```

- Which means the database expects unique Mobile No.

- Non-unique caused KtorClient error 
```Illegal input: Fields [officeId, clientId, resourceId, savingsId] are required for type with serial name 'org.mifospay.core.network.model.ClientResponseEntity', but they were missing at path: $```

- So, added code to ensure unique mobile number along with username in function ```checkUniqueFields```

### Password
- HTTP response BODY contained
```{"developerMessage":"The request was invalid. This typically will happen due to validation errors which are provided.","httpStatusCode":"400","defaultUserMessage":"Validation errors exist.","userMessageGlobalisationCode":"validation.msg.validation.errors.exist","errors":[{"defaultUserMessage":"Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters","parameterName":"password","developerMessage":"Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters","userMessageGlobalisationCode":"validation.msg.user.password.does.not.match.regexp","args":[{"value":"Abcdef123456#@@"},{"value":"^(?!.*(.)\\1)(?!.*\\s)(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[^\\w\\s]).{12,50}$"}]}]}```

- Which means the database expects the password to follow these requirements : 
  - Must be between 12 and 50 characters long (not checked properly)
  - At least 1 uppercase character
  - At least 1 lowercase character
  - At least 1 numeric digit
  - At least 1 special character
  - No spaces (not checked for)
  - No consecutive repeating characters (not checked for)

- Weak password caused KtorClient error
```Illegal input: Field 'resourceId' is required for type with serial name 'org.mifospay.core.network.model.CommonResponse', but it was missing at path: $```

- Modified the ```PasswordChecker.kt``` to consider all requirements
- Modified the DialogBox error in ```SignUpViewModel.kt``` to display the requirements if password is weak
##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [✅] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [✅ ] If you have multiple commits please combine them into one commit by squashing them.
