### PR TITLE
refactor(feature:editpassword) : move all hardcoded strings to string resources

### DIFF
--- a/feature/editpassword/src/commonMain/composeResources/values/strings.xml
+++ b/feature/editpassword/src/commonMain/composeResources/values/strings.xml
@@ -9,6 +9,7 @@
     See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
 -->
 <resources>
+    <!-- Edit Password Screen -->
     <string name="feature_editpassword_password_changed_successfully">Password changed successfull</string>
     <string name="feature_editpassword_change_password">Change Password</string>
     <string name="feature_editpassword_current_password">Current Password</string>
@@ -19,4 +20,11 @@
     <string name="feature_editpassword_password_mismatch_error">Password mismatch</string>
     <string name="feature_editpassword_cancel">Cancel</string>
     <string name="feature_editpassword_save">Save</string>
+
+    <!-- EditPasswordViewModel Error Messages -->
+    <string name="feature_editpassword_error_empty_current_password">Please Enter Your Current Password</string>
+    <string name="feature_editpassword_error_same_password">New password cannot be same as current password</string>
+    <string name="feature_editpassword_error_password_min_length">Password must be at least %1$d characters long.</string>
+    <string name="feature_editpassword_error_password_mismatch">Passwords do not match.</string>
+    <string name="feature_editpassword_error_password_weak">Password is weak.</string>
 </resources>

--- a/feature/editpassword/src/commonMain/kotlin/org/mifospay/feature/editpassword/EditPasswordScreen.kt
+++ b/feature/editpassword/src/commonMain/kotlin/org/mifospay/feature/editpassword/EditPasswordScreen.kt
@@ -179,15 +179,29 @@ private fun EditPasswordDialogs(
     onDismissRequest: () -> Unit,
 ) {
     when (dialogState) {
-        is EditPasswordDialog.Error -> MifosBasicDialog(
+        is EditPasswordDialog.Error -> {
+            val message = if (dialogState.formatArgs.isNotEmpty()) {
+                stringResource(dialogState.message, *dialogState.formatArgs.toTypedArray())
+            } else {
+                stringResource(dialogState.message)
+            }
+            MifosBasicDialog(
+                visibilityState = BasicDialogState.Shown(
+                    message = message,
+                ),
+                onDismissRequest = onDismissRequest,
+            )
+        }
+
+        is EditPasswordDialog.Loading -> MifosLoadingDialog(
+            visibilityState = LoadingDialogState.Shown,
+        )
+
+        is EditPasswordDialog.ApiError -> MifosBasicDialog(
             visibilityState = BasicDialogState.Shown(
                 message = dialogState.message,
             ),
             onDismissRequest = onDismissRequest,
-        )
-
-        is EditPasswordDialog.Loading -> MifosLoadingDialog(
-            visibilityState = LoadingDialogState.Shown,
         )
 
         null -> Unit

--- a/feature/editpassword/src/commonMain/kotlin/org/mifospay/feature/editpassword/EditPasswordViewModel.kt
+++ b/feature/editpassword/src/commonMain/kotlin/org/mifospay/feature/editpassword/EditPasswordViewModel.kt
@@ -20,6 +20,13 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import mobile_wallet.feature.editpassword.generated.resources.Res
+import mobile_wallet.feature.editpassword.generated.resources.feature_editpassword_error_empty_current_password
+import mobile_wallet.feature.editpassword.generated.resources.feature_editpassword_error_password_min_length
+import mobile_wallet.feature.editpassword.generated.resources.feature_editpassword_error_password_mismatch
+import mobile_wallet.feature.editpassword.generated.resources.feature_editpassword_error_password_weak
+import mobile_wallet.feature.editpassword.generated.resources.feature_editpassword_error_same_password
+import org.jetbrains.compose.resources.StringResource
 import org.mifospay.core.common.DataState
 import org.mifospay.core.common.getSerialized
 import org.mifospay.core.common.setSerialized
@@ -144,7 +151,7 @@ internal class EditPasswordViewModel(
 
             is DataState.Error -> {
                 mutableStateFlow.update {
-                    it.copy(dialogState = Error(result.exception.message.toString()))
+                    it.copy(dialogState = EditPasswordDialog.ApiError(result.exception.message.toString()))
                 }
             }
 
@@ -157,13 +164,13 @@ internal class EditPasswordViewModel(
     private fun handleSubmitClick() = when {
         state.currentPasswordInput.isEmpty() -> {
             mutableStateFlow.update {
-                it.copy(dialogState = Error("Please Enter Your Current Password"))
+                it.copy(dialogState = Error(Res.string.feature_editpassword_error_empty_current_password))
             }
         }
 
         state.isSamePassword -> {
             mutableStateFlow.update {
-                it.copy(dialogState = Error("New password cannot be same as current password"))
+                it.copy(dialogState = Error(Res.string.feature_editpassword_error_same_password))
             }
         }
 
@@ -171,7 +178,8 @@ internal class EditPasswordViewModel(
             mutableStateFlow.update {
                 it.copy(
                     dialogState = Error(
-                        "Password must be at least $MIN_PASSWORD_LENGTH characters long.",
+                        Res.string.feature_editpassword_error_password_min_length,
+                        listOf(MIN_PASSWORD_LENGTH)
                     ),
                 )
             }
@@ -179,13 +187,13 @@ internal class EditPasswordViewModel(
 
         !state.isPasswordMatch -> {
             mutableStateFlow.update {
-                it.copy(dialogState = Error("Passwords do not match."))
+                it.copy(dialogState = Error(Res.string.feature_editpassword_error_password_mismatch))
             }
         }
 
         !state.isPasswordStrong -> {
             mutableStateFlow.update {
-                it.copy(dialogState = Error("Password is weak."))
+                it.copy(dialogState = Error(Res.string.feature_editpassword_error_password_weak))
             }
         }
 
@@ -225,12 +233,12 @@ internal data class EditPasswordState(
             PasswordStrengthState.WEAK_1,
             PasswordStrengthState.WEAK_2,
             PasswordStrengthState.WEAK_3,
-            -> false
+                -> false
 
             PasswordStrengthState.GOOD,
             PasswordStrengthState.STRONG,
             PasswordStrengthState.VERY_STRONG,
-            -> true
+                -> true
         }
 
     val isPasswordMatch: Boolean
@@ -242,7 +250,11 @@ internal data class EditPasswordState(
 
 internal sealed interface EditPasswordDialog {
     data object Loading : EditPasswordDialog
-    data class Error(val message: String) : EditPasswordDialog
+    data class Error(
+        val message: StringResource,
+        val formatArgs: List<Any> = emptyList()
+    ) : EditPasswordDialog
+    data class ApiError(val message: String) : EditPasswordDialog
 }
 
 internal sealed interface EditPasswordEvent {


### PR DESCRIPTION
## Issue Fix
Fixes #1885 
Jira Task: MW-233 https://mifosforge.jira.com/browse/MW-233
MW-233 Move all hardcoded string to string resources in feature/editpassword

## Screenshots
<img width="360" height="720" alt="Screenshot_20250717_073542" src="https://github.com/user-attachments/assets/376ff882-e431-467d-930d-19a33f759705" />
<img width="360" height="720" alt="Screenshot_20250717_073607" src="https://github.com/user-attachments/assets/c5297fc4-ad0a-44c3-9006-80e11cca1809" />


## Description

This PR moves all hardcoded strings in the feature/editpassword module into string resources :

EditPasswordViewModel.kt to use string resources for validation error messages
EditPasswordScreen.kt to properly resolve StringResource objects in dialog components
Enhanced error dialog system to support parameterized strings (e.g., minimum password length)

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.
