### PR TITLE
fix(feature:savedcards): add serializable to CardAddEditType subclasses

### DIFF
--- a/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/createOrUpdate/CardAddEditType.kt
+++ b/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/createOrUpdate/CardAddEditType.kt
@@ -16,11 +16,13 @@ sealed class CardAddEditType {
 
     abstract val savedCardId: Long?
 
+    @Serializable
     data object AddItem : CardAddEditType() {
         override val savedCardId: Long?
             get() = null
     }
 
+    @Serializable
     data class EditItem(
         override val savedCardId: Long,
     ) : CardAddEditType()


### PR DESCRIPTION
Jira Task: [MW-301](https://mifosforge.jira.com/browse/MW-301)

## Screenshots

https://github.com/user-attachments/assets/c073118c-6c90-4a42-aceb-48c0b7e5bcbd

## Description
- Fixed serialization error that was causing app crashes when navigating to add/edit card screens

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.


[MW-301]: https://mifosforge.jira.com/browse/MW-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ