### PR TITLE
fix: set transparent loading background and home container color

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/org/mifospay/core/designsystem/component/LoadingWheel.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifospay/core/designsystem/component/LoadingWheel.kt
@@ -172,7 +172,7 @@ fun MfOverlayLoadingWheel(
 fun MfLoadingWheel(
     modifier: Modifier = Modifier,
     contentDesc: String = "Loading",
-    backgroundColor: Color = KptTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+    backgroundColor: Color = Color.Transparent,
 ) {
     Box(
         modifier = modifier

--- a/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeScreen.kt
@@ -194,6 +194,7 @@ fun HomeScreenContent(
     MifosScaffold(
         modifier = modifier,
         snackbarHostState = snackbarHostState,
+        containerColor = KptTheme.colorScheme.background,
     ) {
         PullToRefreshBox(
             isRefreshing = isRefreshing,


### PR DESCRIPTION
Jira Task: [MW-303](https://mifosforge.jira.com/browse/MW-303)

## Screenshots

After Fix:


https://github.com/user-attachments/assets/0c5257d8-19b2-41c6-905a-3ad8cccc9f49



## Description
 - Fix grey loading overlay by making MfLoadingWheel background transparent and update HomeScreen container color to background, allowing proper color display across all screens.
 
##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.


[MW-303]: https://mifosforge.jira.com/browse/MW-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ