### PR TITLE
feat(payments): replace SendMoneyScreen with SendMoneyv2Screen, update nav

### DIFF
--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/MifosNavHost.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/MifosNavHost.kt
@@ -54,6 +54,7 @@ import org.mifospay.feature.make.transfer.v2.navigateToMakeTransferScreenV2
 import org.mifospay.feature.merchants.navigation.merchantTransferScreen
 import org.mifospay.feature.notification.navigateToNotification
 import org.mifospay.feature.notification.notificationScreen
+import org.mifospay.feature.payments.PAYMENTS_ROUTE
 import org.mifospay.feature.payments.PaymentsScreenContents
 import org.mifospay.feature.payments.RequestScreen
 import org.mifospay.feature.payments.paymentsScreen
@@ -66,12 +67,12 @@ import org.mifospay.feature.request.money.navigation.navigateToShowQrScreen
 import org.mifospay.feature.request.money.navigation.showQrScreen
 import org.mifospay.feature.savedcards.createOrUpdate.addEditCardScreen
 import org.mifospay.feature.savedcards.details.cardDetailRoute
-import org.mifospay.feature.send.money.SendMoneyScreen
 import org.mifospay.feature.send.money.navigation.SEND_MONEY_BASE_ROUTE
 import org.mifospay.feature.send.money.navigation.navigateToSendMoneyScreen
 import org.mifospay.feature.send.money.navigation.sendMoneyScreen
 import org.mifospay.feature.send.money.selectScreen.navigateToSelectAccountScreen
 import org.mifospay.feature.send.money.selectScreen.selectAccountScreenDestination
+import org.mifospay.feature.send.money.v2.SendMoneyv2Screen
 import org.mifospay.feature.send.money.v2.navigateToSendMoneyV2Screen
 import org.mifospay.feature.send.money.v2.sendMoneyScreenDestination
 import org.mifospay.feature.settings.navigation.settingsScreen
@@ -90,10 +91,16 @@ internal fun MifosNavHost(
 
     val paymentsTabContents = listOf(
         TabContent(PaymentsScreenContents.SEND.name) {
-            SendMoneyScreen(
-                onBackClick = navController::navigateUp,
-                navigateToTransferScreen = navController::navigateToTransferScreen,
-                navigateToScanQrScreen = navController::navigateToScanQr,
+            SendMoneyv2Screen(
+                navigateToSelectAccountScreen = {
+                    navController.navigateToSelectAccountScreen(returnDestination = "payments")
+                },
+                navigateBack = {
+                    navController.navigateUp()
+                },
+                navigateToBeneficiary = {
+                    navController.navigateToBeneficiaryAddEdit(BeneficiaryAddEditType.AddItem)
+                },
                 showTopBar = false,
             )
         },
@@ -293,11 +300,13 @@ internal fun MifosNavHost(
 
         makeTransferScreenV2(
             navigateBack = navController::popBackStack,
-            onTransferSuccess = {
+            onTransferSuccess = { returnDestination ->
                 navController.navigateTransferSuccess(
+                    returnDestination = returnDestination,
                     navOptions {
-                        popUpTo(SEND_MONEY_BASE_ROUTE) {
-                            inclusive = true
+                        when (returnDestination) {
+                            "payments" -> popUpTo(PAYMENTS_ROUTE) { inclusive = true }
+                            else -> popUpTo(SEND_MONEY_BASE_ROUTE) { inclusive = true }
                         }
                         launchSingleTop = true
                     },
@@ -321,6 +330,7 @@ internal fun MifosNavHost(
             navigateBack = navController::popBackStack,
             onTransferSuccess = {
                 navController.navigateTransferSuccess(
+                    returnDestination = "home",
                     navOptions {
                         popUpTo(SEND_MONEY_BASE_ROUTE) {
                             inclusive = true
@@ -332,12 +342,24 @@ internal fun MifosNavHost(
         )
 
         transferSuccessScreen(
-            navigateBack = {
-                navController.navigate(HOME_ROUTE) {
-                    popUpTo(HOME_ROUTE) {
-                        inclusive = false
+            navigateBack = { returnDestination ->
+                when (returnDestination) {
+                    "payments" -> {
+                        navController.navigate(PAYMENTS_ROUTE) {
+                            popUpTo(PAYMENTS_ROUTE) {
+                                inclusive = false
+                            }
+                            launchSingleTop = true
+                        }
                     }
-                    launchSingleTop = true
+                    else -> {
+                        navController.navigate(HOME_ROUTE) {
+                            popUpTo(HOME_ROUTE) {
+                                inclusive = false
+                            }
+                            launchSingleTop = true
+                        }
+                    }
                 }
             },
         )

--- a/feature/make-transfer/src/commonMain/composeResources/values/strings.xml
+++ b/feature/make-transfer/src/commonMain/composeResources/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="feature_make_transfer_icon_selected_description">Selected account indicator</string>
 
 <!--  Transfer Success Screen  -->
-    <string name="feature_make_transfer_back_to_home">Back To Home</string>
+    <string name="feature_make_transfer_continue">Continue</string>
     <string name="feature_make_transfer_success">Success</string>
     <string name="feature_make_transfer_payment_success">Payment Success</string>
     <string name="feature_make_transfer_payment_done">Your payment has been successfully done.</string>

--- a/feature/make-transfer/src/commonMain/kotlin/org/mifospay/feature/make/transfer/success/TransferSuccessNavigation.kt
+++ b/feature/make-transfer/src/commonMain/kotlin/org/mifospay/feature/make/transfer/success/TransferSuccessNavigation.kt
@@ -12,22 +12,32 @@ package org.mifospay.feature.make.transfer.success
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import org.mifospay.core.ui.composableWithSlideTransitions
+import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import kotlinx.serialization.Serializable
 
-private const val TRANSFER_SUCCESS_ROUTE = "transfer_success_route"
+@Serializable
+data class TransferSuccessRoute(
+    val returnDestination: String = "home",
+)
 
 fun NavGraphBuilder.transferSuccessScreen(
-    navigateBack: () -> Unit,
+    navigateBack: (String) -> Unit,
 ) {
-    composableWithSlideTransitions(route = TRANSFER_SUCCESS_ROUTE) {
+    composable<TransferSuccessRoute> { backStackEntry ->
+        val route = backStackEntry.toRoute<TransferSuccessRoute>()
         TransferSuccessScreen(
-            navigateBack = navigateBack,
+            navigateBack = { navigateBack(route.returnDestination) },
         )
     }
 }
 
 fun NavController.navigateTransferSuccess(
+    returnDestination: String = "home",
     navOptions: NavOptions? = null,
 ) {
-    navigate(TRANSFER_SUCCESS_ROUTE, navOptions)
+    navigate(
+        TransferSuccessRoute(returnDestination = returnDestination),
+        navOptions,
+    )
 }

--- a/feature/make-transfer/src/commonMain/kotlin/org/mifospay/feature/make/transfer/success/TransferSuccessScreen.kt
+++ b/feature/make-transfer/src/commonMain/kotlin/org/mifospay/feature/make/transfer/success/TransferSuccessScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import mobile_wallet.feature.make_transfer.generated.resources.Res
-import mobile_wallet.feature.make_transfer.generated.resources.feature_make_transfer_back_to_home
+import mobile_wallet.feature.make_transfer.generated.resources.feature_make_transfer_continue
 import mobile_wallet.feature.make_transfer.generated.resources.feature_make_transfer_payment_done
 import mobile_wallet.feature.make_transfer.generated.resources.feature_make_transfer_payment_success
 import mobile_wallet.feature.make_transfer.generated.resources.feature_make_transfer_success
@@ -52,7 +52,7 @@ internal fun TransferSuccessScreen(
                         .fillMaxWidth()
                         .padding(KptTheme.spacing.md),
                 ) {
-                    Text(text = stringResource(Res.string.feature_make_transfer_back_to_home))
+                    Text(text = stringResource(Res.string.feature_make_transfer_continue))
                 }
             }
         },

--- a/feature/make-transfer/src/commonMain/kotlin/org/mifospay/feature/make/transfer/v2/MakeTransferScreenV2Navigation.kt
+++ b/feature/make-transfer/src/commonMain/kotlin/org/mifospay/feature/make/transfer/v2/MakeTransferScreenV2Navigation.kt
@@ -13,6 +13,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -24,6 +25,7 @@ data class MakeTransferScreenV2Route(
     val toAccountTypeId: Int? = null,
     val toAccountName: String = "",
     val toAccountNo: String = "",
+    val returnDestination: String = "home",
 )
 
 fun NavController.navigateToMakeTransferScreenV2(
@@ -34,6 +36,7 @@ fun NavController.navigateToMakeTransferScreenV2(
     amount: Int,
     toAccountName: String,
     toAccountNo: String,
+    returnDestination: String = "home",
     navOptions: NavOptions? = null,
 ) {
     this.navigate(
@@ -41,11 +44,11 @@ fun NavController.navigateToMakeTransferScreenV2(
             toOfficeId = toOfficeId,
             toClientId = toClientId,
             toAccountTypeId = toAccountTypeId,
-
             accountId = toAccountId.toLong(),
             amount = amount,
             toAccountName = toAccountName,
             toAccountNo = toAccountNo,
+            returnDestination = returnDestination,
         ),
         navOptions,
     )
@@ -53,12 +56,13 @@ fun NavController.navigateToMakeTransferScreenV2(
 
 fun NavGraphBuilder.makeTransferScreenV2(
     navigateBack: () -> Unit,
-    onTransferSuccess: () -> Unit,
+    onTransferSuccess: (String) -> Unit,
 ) {
-    composable<MakeTransferScreenV2Route> {
+    composable<MakeTransferScreenV2Route> { backStackEntry ->
+        val route = backStackEntry.toRoute<MakeTransferScreenV2Route>()
         MakeTransferScreenV2(
             navigateBack = navigateBack,
-            onTransferSuccess = onTransferSuccess,
+            onTransferSuccess = { onTransferSuccess(route.returnDestination) },
         )
     }
 }

--- a/feature/send-money/src/commonMain/kotlin/org/mifospay/feature/send/money/selectScreen/SelectScreenNavigation.kt
+++ b/feature/send-money/src/commonMain/kotlin/org/mifospay/feature/send/money/selectScreen/SelectScreenNavigation.kt
@@ -13,13 +13,19 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object SelectAccountRoute
+data class SelectAccountRoute(
+    val returnDestination: String = "home",
+)
 
-fun NavController.navigateToSelectAccountScreen(navOptions: NavOptions? = null) {
-    this.navigate(SelectAccountRoute, navOptions)
+fun NavController.navigateToSelectAccountScreen(
+    returnDestination: String = "home",
+    navOptions: NavOptions? = null,
+) {
+    this.navigate(SelectAccountRoute(returnDestination = returnDestination), navOptions)
 }
 
 fun NavGraphBuilder.selectAccountScreenDestination(
@@ -32,11 +38,15 @@ fun NavGraphBuilder.selectAccountScreenDestination(
         amount: Int,
         accountName: String,
         accountNo: String,
+        returnDestination: String,
     ) -> Unit,
 ) {
-    composable<SelectAccountRoute> {
+    composable<SelectAccountRoute> { backStackEntry ->
+        val route = backStackEntry.toRoute<SelectAccountRoute>()
         SelectPayeeScreen(
-            navigateToMakeTransferV2Screen = navigateToMakeTransferV2Screen,
+            navigateToMakeTransferV2Screen = { toOfficeId, toClientId, toAccountTypeId, toAccountId, amount, accountName, accountNo ->
+                navigateToMakeTransferV2Screen(toOfficeId, toClientId, toAccountTypeId, toAccountId, amount, accountName, accountNo, route.returnDestination)
+            },
             navigateBack = navigateBack,
         )
     }

--- a/feature/send-money/src/commonMain/kotlin/org/mifospay/feature/send/money/v2/SendMoneyv2Navigation.kt
+++ b/feature/send-money/src/commonMain/kotlin/org/mifospay/feature/send/money/v2/SendMoneyv2Navigation.kt
@@ -26,12 +26,14 @@ fun NavGraphBuilder.sendMoneyScreenDestination(
     navigateToSelectAccountScreen: () -> Unit,
     navigateToBeneficiary: () -> Unit,
     navigateBack: () -> Unit,
+    showTopBar: Boolean = true,
 ) {
     composable<SendMoneyRoute> {
         SendMoneyv2Screen(
             navigateToSelectAccountScreen = navigateToSelectAccountScreen,
             navigateBack = navigateBack,
             navigateToBeneficiary = navigateToBeneficiary,
+            showTopBar = showTopBar,
         )
     }
 }

--- a/feature/send-money/src/commonMain/kotlin/org/mifospay/feature/send/money/v2/SendMoneyv2Screen.kt
+++ b/feature/send-money/src/commonMain/kotlin/org/mifospay/feature/send/money/v2/SendMoneyv2Screen.kt
@@ -63,6 +63,7 @@ fun SendMoneyv2Screen(
     navigateBack: () -> Unit,
     navigateToBeneficiary: () -> Unit,
     modifier: Modifier = Modifier,
+    showTopBar: Boolean = true,
     viewModel: SendMoneyV2ViewModel = koinViewModel(),
 ) {
     EventsEffect(viewModel) { event ->
@@ -77,6 +78,7 @@ fun SendMoneyv2Screen(
 
     SendMoneyScreen(
         modifier = modifier,
+        showTopBar = showTopBar,
         onAction = remember(viewModel) {
             { viewModel.trySendAction(it) }
         },
@@ -87,17 +89,20 @@ fun SendMoneyv2Screen(
 @Composable
 private fun SendMoneyScreen(
     modifier: Modifier = Modifier,
+    showTopBar: Boolean = true,
     onAction: (SendMoneyV2Action) -> Unit,
 ) {
     MifosBottomSheetScaffold(
         modifier = modifier,
         topBar = {
-            MifosTopBar(
-                topBarTitle = stringResource(Res.string.feature_send_money_send),
-                backPress = {
-                    onAction(SendMoneyV2Action.NavigateBack)
-                },
-            )
+            if (showTopBar) {
+                MifosTopBar(
+                    topBarTitle = stringResource(Res.string.feature_send_money_send),
+                    backPress = {
+                        onAction(SendMoneyV2Action.NavigateBack)
+                    },
+                )
+            }
         },
         sheetContent = {
             // TODO : If we can get recent payment details in self with toAccount number and  amount
@@ -107,8 +112,12 @@ private fun SendMoneyScreen(
         sheetPeekHeight = 0.dp,
     ) { paddingValues ->
         Column(
-            Modifier.fillMaxSize().padding(paddingValues).padding(horizontal = KptTheme.spacing.md),
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = KptTheme.spacing.md),
         ) {
+            Spacer(Modifier.height(KptTheme.spacing.md))
+
             SimpleSearchBar(
                 query = "",
                 placeHolder = stringResource(Res.string.feature_select_account_placeholder),
@@ -118,7 +127,9 @@ private fun SendMoneyScreen(
                 },
                 enabled = false,
             )
+
             Spacer(Modifier.height(KptTheme.spacing.md))
+
             AddPayeeCard(
                 onClick = {
                     onAction(SendMoneyV2Action.OnAddPayeeClicked)


### PR DESCRIPTION
Jira Task: [MW-317](https://mifosforge.jira.com/browse/MW-317)

## Screenshots

After Fix:

https://github.com/user-attachments/assets/af0fd72f-802a-45e2-ac8a-bb4a31d187c0

## Description
- Replaced legacy SendMoneyScreen with SendMoneyv2Screen in Payments tab
- Added showTopBar flag and set false when embedded in Payments tab
- Updated navigation parameters for v2 flow
- Implemented navigation: 
  - Payments tab → Send Money → Success → back to Payments tab (Send Money section)
  - Send Money → Success → Home

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.


[MW-317]: https://mifosforge.jira.com/browse/MW-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ