### PR TITLE
feat(feature:auth): make address line 2 optional

### DIFF
--- a/feature/auth/src/commonMain/composeResources/values/strings.xml
+++ b/feature/auth/src/commonMain/composeResources/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="feature_auth_or">or</string>
     <string name="feature_auth_google_account">Ease my sign-up using Google Account</string>
     <string name="feature_auth_validate_email">Please enter a valid email address</string>
-    <string name="feature_auth_all_fields_are_mandatory">All fields are mandatory.</string>
+    <string name="feature_auth_all_fields_are_mandatory">All fields are mandatory except Address Line 2.</string>
     <string name="feature_auth_complete_your_registration">Complete your registration</string>
 
     <!-- Labels -->
@@ -33,7 +33,7 @@
     <string name="feature_auth_confirm_password">Confirm Password</string>
     <string name="feature_auth_name_of_business">Name of Business</string>
     <string name="feature_auth_address_line_1">Address Line 1</string>
-    <string name="feature_auth_address_line_2">Address Line 2</string>
+    <string name="feature_auth_address_line_2">Address Line 2 (optional)</string>
     <string name="feature_auth_pin_code">Pin Code</string>
     <string name="feature_auth_state">State</string>
     <string name="feature_auth_country">Country</string>
@@ -69,7 +69,6 @@
     <string name="feature_auth_error_confirm_password_required">The confirm password field cannot be empty.</string>
     <string name="feature_auth_error_passwords_mismatch">Passwords do not match.</string>
     <string name="feature_auth_error_address_line1_required">Please enter your address line 1.</string>
-    <string name="feature_auth_error_address_line2_required">Please enter your address line 2.</string>
     <string name="feature_auth_error_pincode_required">Please enter your pin code.</string>
     <string name="feature_auth_error_country_required">Please enter your country.</string>
     <string name="feature_auth_error_state_required">Please enter your state.</string>

--- a/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/signup/SignupViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/signup/SignupViewModel.kt
@@ -26,7 +26,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import mobile_wallet.feature.auth.generated.resources.Res
 import mobile_wallet.feature.auth.generated.resources.feature_auth_error_address_line1_required
-import mobile_wallet.feature.auth.generated.resources.feature_auth_error_address_line2_required
 import mobile_wallet.feature.auth.generated.resources.feature_auth_error_check_uniqueness_failed
 import mobile_wallet.feature.auth.generated.resources.feature_auth_error_confirm_password_required
 import mobile_wallet.feature.auth.generated.resources.feature_auth_error_country_required
@@ -382,14 +381,6 @@ class SignupViewModel(
             mutableStateFlow.update {
                 it.copy(
                     dialogState = DialogState.Error.ResourceMessage(Res.string.feature_auth_error_address_line1_required),
-                )
-            }
-        }
-
-        state.addressLine2Input.isEmpty() -> {
-            mutableStateFlow.update {
-                it.copy(
-                    dialogState = DialogState.Error.ResourceMessage(Res.string.feature_auth_error_address_line2_required),
                 )
             }
         }


### PR DESCRIPTION
Jira Task: [MW-325](https://mifosforge.jira.com/browse/MW-325)

## Screenshots

[After-Fix-Address-Line2-Optional.webm](https://github.com/user-attachments/assets/1e7d523f-e29e-40a0-8cbb-0e653a1a9948)

## Description
 - Removed validation requirement for Address Line 2 field
 - Updated form subtitle to indicate Address Line 2 is optional
 - Marked Address Line 2 as optional

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.


[MW-325]: https://mifosforge.jira.com/browse/MW-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ