### PR TITLE
feat(passcode): implement change passcode flow (MW-324)

### DIFF
--- a/cmp-shared/cmp_shared.podspec
+++ b/cmp-shared/cmp_shared.podspec
@@ -50,5 +50,5 @@ Pod::Spec.new do |spec|
             SCRIPT
         }
     ]
-    spec.resources = ['build/compose/cocoapods/compose-resources']
+    spec.resources = ['build\compose\cocoapods\compose-resources']
 end

--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/MifosPayApp.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/MifosPayApp.kt
@@ -16,9 +16,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
+import org.mifos.library.passcode.Intention
 import org.mifospay.core.common.GlobalAuthManager
 import org.mifospay.core.data.util.NetworkMonitor
 import org.mifospay.core.data.util.TimeZoneMonitor
@@ -26,7 +28,8 @@ import org.mifospay.core.designsystem.component.MifosDialogBox
 import org.mifospay.core.designsystem.theme.MifosTheme
 import org.mifospay.shared.MainUiState.Success
 import org.mifospay.shared.navigation.MifosNavGraph.LOGIN_GRAPH
-import org.mifospay.shared.navigation.MifosNavGraph.PASSCODE_GRAPH
+import org.mifospay.shared.navigation.MifosNavGraph.MAIN_GRAPH
+import org.mifospay.shared.navigation.MifosNavGraph.passcodeGraphRoute
 import org.mifospay.shared.navigation.RootNavGraph
 
 @Composable
@@ -77,13 +80,25 @@ private fun MifosPayApp(
         )
     }
 
-    val navDestination = when (uiState) {
-        is MainUiState.Loading -> LOGIN_GRAPH
-        is Success -> if ((uiState as Success).userData.authenticated) {
-            PASSCODE_GRAPH
-        } else {
-            LOGIN_GRAPH
+    // Navigation logic:
+    // 1. If still loading -> LOGIN_GRAPH (temporary until we know auth state)
+    // 2. If not authenticated -> LOGIN_GRAPH
+    // 3. If authenticated AND has passcode -> PASSCODE_GRAPH with LOGIN_WITH_PASSCODE intention (verify)
+    // 4. If authenticated AND skipped passcode setup -> MAIN_GRAPH (user chose to skip)
+    // 5. If authenticated but no passcode and not skipped -> PASSCODE_GRAPH with CREATE_PASSCODE intention (first time)
+    val navDestination = when {
+        uiState is Success -> {
+            val userData = (uiState as Success).userData
+            val hasPasscode = (uiState as Success).hasPasscode
+            val hasSkippedPasscodeSetup = (uiState as Success).hasSkippedPasscodeSetup
+            when {
+                !userData.authenticated -> LOGIN_GRAPH
+                hasPasscode -> passcodeGraphRoute(Intention.LOGIN_WITH_PASSCODE)
+                hasSkippedPasscodeSetup -> MAIN_GRAPH
+                else -> passcodeGraphRoute(Intention.CREATE_PASSCODE)
+            }
         }
+        else -> LOGIN_GRAPH
     }
 
     MifosTheme {

--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/MifosPayViewModel.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/MifosPayViewModel.kt
@@ -25,7 +25,9 @@ class MifosPayViewModel(
     private val passcodeManager: PasscodeManager,
 ) : ViewModel() {
     val uiState: StateFlow<MainUiState> = userDataRepository.userInfo.map {
-        MainUiState.Success(it)
+        val hasPasscode = passcodeManager.hasPasscode.value
+        val hasSkippedPasscodeSetup = passcodeManager.hasSkippedPasscodeSetup.value
+        MainUiState.Success(it, hasPasscode, hasSkippedPasscodeSetup)
     }.stateIn(
         scope = viewModelScope,
         initialValue = MainUiState.Loading,
@@ -42,5 +44,9 @@ class MifosPayViewModel(
 
 sealed interface MainUiState {
     data object Loading : MainUiState
-    data class Success(val userData: UserInfo) : MainUiState
+    data class Success(
+        val userData: UserInfo,
+        val hasPasscode: Boolean,
+        val hasSkippedPasscodeSetup: Boolean,
+    ) : MainUiState
 }

--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/LoginNavGraph.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/LoginNavGraph.kt
@@ -12,7 +12,6 @@ package org.mifospay.shared.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.navigation
-import org.mifos.library.passcode.navigateToPasscodeScreen
 import org.mifospay.feature.auth.navigation.LOGIN_ROUTE
 import org.mifospay.feature.auth.navigation.loginScreen
 import org.mifospay.feature.auth.navigation.mobileVerificationScreen
@@ -29,7 +28,6 @@ internal fun NavGraphBuilder.loginNavGraph(navController: NavController) {
     ) {
         loginScreen(
             onNavigateBack = navController::popBackStack,
-            onNavigateToPasscodeScreen = navController::navigateToPasscodeScreen,
             onNavigateToSignupScreen = navController::navigateToSignupMethod,
         )
 

--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/MifosNavGraph.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/MifosNavGraph.kt
@@ -9,9 +9,19 @@
  */
 package org.mifospay.shared.navigation
 
+import org.mifos.library.passcode.Intention
+
 internal object MifosNavGraph {
     const val ROOT_GRAPH = "root_graph"
     const val LOGIN_GRAPH = "login_graph"
-    const val PASSCODE_GRAPH = "passcode_graph"
     const val MAIN_GRAPH = "main_graph"
+
+    // Passcode graph with intention parameter
+    private const val PASSCODE_GRAPH_BASE = "passcode_graph"
+    private const val INTENTION_ARG = "intention"
+    const val PASSCODE_GRAPH_ROUTE = "$PASSCODE_GRAPH_BASE?$INTENTION_ARG={$INTENTION_ARG}"
+
+    fun passcodeGraphRoute(intention: Intention): String {
+        return "$PASSCODE_GRAPH_BASE?$INTENTION_ARG=${intention.value}"
+    }
 }

--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/MifosNavHost.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/MifosNavHost.kt
@@ -11,8 +11,11 @@ package org.mifospay.shared.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
+import org.mifos.library.passcode.Intention
+import org.mifos.library.passcode.navigateToPasscodeScreen
 import org.mifospay.core.ui.utility.TabContent
 import org.mifospay.feature.accounts.AccountsScreen
 import org.mifospay.feature.accounts.beneficiary.BeneficiaryAddEditType
@@ -88,6 +91,7 @@ import org.mifospay.shared.ui.MifosAppState
 internal fun MifosNavHost(
     appState: MifosAppState,
     onClickLogout: () -> Unit,
+    rootNavController: NavHostController,
     modifier: Modifier = Modifier,
 ) {
     val navController = appState.navController
@@ -180,7 +184,11 @@ internal fun MifosNavHost(
         settingsScreen(
             onBackPress = navController::navigateUp,
             onLogout = onClickLogout,
-            onChangePasscode = {},
+            onChangePasscode = {
+                rootNavController.navigateToPasscodeScreen(
+                    intention = Intention.CHANGE_PASSCODE,
+                )
+            },
             navigateToEditPasswordScreen = navController::navigateToEditPassword,
             navigateToFaqScreen = navController::navigateToFAQ,
             navigateToNotificationScreen = navController::navigateToNotification,

--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/PasscodeNavGraph.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/PasscodeNavGraph.kt
@@ -14,28 +14,27 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.navOptions
 import androidx.navigation.navigation
+import org.mifos.library.passcode.INTENTION
 import org.mifos.library.passcode.PASSCODE_SCREEN
 import org.mifos.library.passcode.passcodeRoute
+import org.mifospay.feature.auth.navigation.navigateToLogin
 
 internal fun NavGraphBuilder.passcodeNavGraph(navController: NavController) {
     navigation(
-        route = MifosNavGraph.PASSCODE_GRAPH,
-        startDestination = PASSCODE_SCREEN,
+        // Start destination includes the intention placeholder so it's inherited from the graph route
+        startDestination = "$PASSCODE_SCREEN?$INTENTION={$INTENTION}",
+        route = MifosNavGraph.PASSCODE_GRAPH_ROUTE,
     ) {
         passcodeRoute(
             onForgotButton = {
                 navController.popBackStack()
-                navController.navigateToMainGraph()
+                navController.navigateToLogin()
             },
             onSkipButton = {
                 navController.popBackStack()
                 navController.navigateToMainGraph()
             },
-            onPasscodeConfirm = {
-                navController.popBackStack()
-                navController.navigateToMainGraph()
-            },
-            onPasscodeRejected = {
+            onPasscodeFlowComplete = {
                 navController.popBackStack()
                 navController.navigateToMainGraph()
             },

--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/RootNavGraph.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/RootNavGraph.kt
@@ -42,6 +42,7 @@ internal fun RootNavGraph(
                 networkMonitor = networkMonitor,
                 timeZoneMonitor = timeZoneMonitor,
                 onClickLogout = onClickLogout,
+                rootNavController = navHostController,
             )
         }
     }

--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/ui/MifosApp.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/ui/MifosApp.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavHostController
 import mobile_wallet.cmp_shared.generated.resources.Res
 import mobile_wallet.cmp_shared.generated.resources.not_connected
 import org.jetbrains.compose.resources.stringResource
@@ -69,6 +70,7 @@ internal fun MifosApp(
     networkMonitor: NetworkMonitor,
     timeZoneMonitor: TimeZoneMonitor,
     onClickLogout: () -> Unit,
+    rootNavController: NavHostController,
     modifier: Modifier = Modifier,
 ) {
     MifosGradientBackground(
@@ -158,6 +160,7 @@ internal fun MifosApp(
                     MifosNavHost(
                         appState = appState,
                         onClickLogout = onClickLogout,
+                        rootNavController = rootNavController,
                     )
                 }
             }

--- a/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/login/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/login/LoginScreen.kt
@@ -57,7 +57,6 @@ import template.core.base.designsystem.theme.KptTheme
 @Composable
 internal fun LoginScreen(
     onNavigateBack: () -> Unit,
-    navigateToPasscodeScreen: () -> Unit,
     navigateToSignupScreen: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel = koinViewModel(),
@@ -71,7 +70,6 @@ internal fun LoginScreen(
         when (event) {
             is LoginEvent.NavigateBack -> onNavigateBack.invoke()
             is LoginEvent.NavigateToSignup -> navigateToSignupScreen.invoke()
-            is LoginEvent.NavigateToPasscodeScreen -> navigateToPasscodeScreen.invoke()
             is LoginEvent.ShowToast -> {
                 scope.launch {
                     snackbarHostState.showSnackbar(event.message)

--- a/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/login/LoginViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/login/LoginViewModel.kt
@@ -102,7 +102,6 @@ class LoginViewModel(
                 mutableStateFlow.update {
                     it.copy(dialogState = null)
                 }
-                sendEvent(LoginEvent.NavigateToPasscodeScreen)
             }
         }
     }
@@ -140,7 +139,6 @@ data class LoginState(
 sealed class LoginEvent {
     data object NavigateBack : LoginEvent()
     data object NavigateToSignup : LoginEvent()
-    data object NavigateToPasscodeScreen : LoginEvent()
     data class ShowToast(val message: String) : LoginEvent()
 }
 

--- a/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/navigation/LoginScreenNavigation.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifospay/feature/auth/navigation/LoginScreenNavigation.kt
@@ -20,7 +20,6 @@ const val LOGIN_ROUTE = "login_route"
 
 fun NavGraphBuilder.loginScreen(
     onNavigateBack: () -> Unit,
-    onNavigateToPasscodeScreen: () -> Unit,
     onNavigateToSignupScreen: () -> Unit,
 ) {
     composable(
@@ -34,7 +33,6 @@ fun NavGraphBuilder.loginScreen(
     ) {
         LoginScreen(
             onNavigateBack = onNavigateBack,
-            navigateToPasscodeScreen = onNavigateToPasscodeScreen,
             navigateToSignupScreen = onNavigateToSignupScreen,
         )
     }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
             implementation(compose.material3)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
-
+            implementation(projects.libs.mifosPasscode)
             implementation(libs.koin.compose.viewmodel)
             implementation(libs.koin.compose)
         }

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="feature_settings_settings">Settings</string>
     <string name="feature_settings_change_password">Change Password</string>
     <string name="feature_settings_change_passcode">Change Passcode</string>
+    <string name="feature_settings_create_passcode">Create Passcode</string>
     <string name="feature_settings_log_out">Log out</string>
     <string name="feature_settings_disable_account">Disable account</string>
     <string name="feature_settings_alert_disable_account_desc">This will delete all the information about your account</string>

--- a/feature/settings/src/commonMain/kotlin/org/mifospay/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifospay/feature/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mobile_wallet.feature.settings.generated.resources.Res
 import mobile_wallet.feature.settings.generated.resources.feature_settings_change_passcode
 import mobile_wallet.feature.settings.generated.resources.feature_settings_change_password
+import mobile_wallet.feature.settings.generated.resources.feature_settings_create_passcode
 import mobile_wallet.feature.settings.generated.resources.feature_settings_disable_account
 import mobile_wallet.feature.settings.generated.resources.feature_settings_faq
 import mobile_wallet.feature.settings.generated.resources.feature_settings_log_out
@@ -63,6 +64,7 @@ internal fun SettingsScreenRoute(
     viewmodel: SettingsViewModel = koinViewModel(),
 ) {
     val state by viewmodel.stateFlow.collectAsStateWithLifecycle()
+    val hasPasscode by viewmodel.hasPasscode.collectAsStateWithLifecycle()
 
     EventsEffect(viewmodel) { event ->
         when (event) {
@@ -86,6 +88,7 @@ internal fun SettingsScreenRoute(
         SettingsScreenContent(
             modifier = Modifier,
             onAction = viewmodel::trySendAction,
+            hasPasscode = hasPasscode,
         )
     }
 }
@@ -94,6 +97,7 @@ internal fun SettingsScreenRoute(
 private fun SettingsScreenContent(
     modifier: Modifier = Modifier,
     onAction: (SettingsAction) -> Unit,
+    hasPasscode: Boolean,
 ) {
     MifosScaffold(
         modifier = modifier,
@@ -135,7 +139,7 @@ private fun SettingsScreenContent(
             )
 
             SettingsCardItem(
-                title = stringResource(Res.string.feature_settings_change_passcode),
+                title = if (hasPasscode) stringResource(Res.string.feature_settings_change_passcode) else stringResource(Res.string.feature_settings_create_passcode),
                 icon = vectorResource(Res.drawable.outline_pin),
                 onClick = {
                     onAction(SettingsAction.ChangePasscode)
@@ -240,5 +244,6 @@ private fun SettingsDialogs(
 private fun SettingsScreenPreview() {
     SettingsScreenContent(
         onAction = {},
+        hasPasscode = false,
     )
 }

--- a/feature/settings/src/commonMain/kotlin/org/mifospay/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifospay/feature/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@
 package org.mifospay.feature.settings
 
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import mobile_wallet.feature.settings.generated.resources.Res
@@ -24,10 +25,12 @@ import org.mifospay.core.datastore.UserPreferencesRepository
 import org.mifospay.core.model.client.Client
 import org.mifospay.core.ui.utils.BaseViewModel
 import org.mifospay.feature.settings.SettingsAction.Internal.DisableAccountResult
+import proto.org.mifos.library.passcode.data.PasscodeManager
 
 class SettingsViewModel(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val repository: SavingsAccountRepository,
+    private val passcodeRepository: PasscodeManager,
 ) : BaseViewModel<SettingsState, SettingsEvent, SettingsAction>(
     initialState = run {
         val client = requireNotNull(userPreferencesRepository.client.value)
@@ -38,6 +41,7 @@ class SettingsViewModel(
         )
     },
 ) {
+    val hasPasscode: StateFlow<Boolean> = passcodeRepository.hasPasscode
 
     override fun handleAction(action: SettingsAction) {
         when (action) {

--- a/libs/mifos-passcode/src/commonMain/composeResources/values/strings.xml
+++ b/libs/mifos-passcode/src/commonMain/composeResources/values/strings.xml
@@ -18,7 +18,10 @@
     <string name="lib_mifos_passcode">passcode</string>
     <string name="lib_mifos_passcode_drag_passcode">drag_passcode</string>
 
+    <string name="library_mifos_passcode_done">Done</string>
+    <string name="library_mifos_passcode_passcode_changed_message">Your passcode has been updated.</string>
     <string name="library_mifos_passcode_create_passcode">Create Passcode</string>
+    <string name="library_mifos_passcode_create_new_passcode">Create new Passcode</string>
     <string name="library_mifos_passcode_confirm_passcode">Confirm Passcode</string>
     <string name="library_mifos_passcode_enter_your_passcode">Enter your Passcode</string>
     <string name="library_mifos_passcode_forgot_passcode">Forgot Passcode</string>

--- a/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/PassCodeScreen.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/PassCodeScreen.kt
@@ -46,6 +46,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
+import org.mifos.library.passcode.component.ChangePasscodeSuccessDialog
 import org.mifos.library.passcode.component.MifosIcon
 import org.mifos.library.passcode.component.PasscodeForgotButton
 import org.mifos.library.passcode.component.PasscodeHeader
@@ -65,8 +66,7 @@ import org.mifospay.core.ui.utils.EventsEffect
 internal fun PasscodeScreen(
     onForgotButton: () -> Unit,
     onSkipButton: () -> Unit,
-    onPasscodeConfirm: (String) -> Unit,
-    onPasscodeRejected: () -> Unit,
+    onPasscodeFlowComplete: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PasscodeViewModel = koinViewModel(),
 ) {
@@ -79,7 +79,7 @@ internal fun PasscodeScreen(
     EventsEffect(viewModel) { event ->
         when (event) {
             is PasscodeEvent.PasscodeConfirmed -> {
-                onPasscodeConfirm(event.passcode)
+                onPasscodeFlowComplete()
             }
 
             is PasscodeEvent.PasscodeRejected -> {
@@ -87,8 +87,9 @@ internal fun PasscodeScreen(
                 scope.launch {
                     performShakeAnimation(xShake)
                 }
-                onPasscodeRejected()
             }
+
+            is PasscodeEvent.PasscodeSetupSkipped -> onSkipButton()
         }
     }
 
@@ -106,11 +107,18 @@ internal fun PasscodeScreen(
             PasscodeToolbar(activeStep = state.activeStep, state.hasPasscode)
 
             PasscodeSkipButton(
-                hasPassCode = state.hasPasscode,
-                onSkipButton = onSkipButton,
+                intention = state.intention,
+                onSkipButton = {
+                    viewModel.trySendAction(PasscodeAction.SkipPasscodeSetup)
+                },
             )
 
             MifosIcon(modifier = Modifier.fillMaxWidth())
+
+            ChangePasscodeSuccessDialog(
+                visible = state.isChangePasscodeSuccessful,
+                onDismiss = { viewModel.trySendAction(PasscodeAction.DismissChangePasscodeSuccessDialog) },
+            )
 
             Column(
                 modifier = Modifier
@@ -120,7 +128,7 @@ internal fun PasscodeScreen(
             ) {
                 PasscodeHeader(
                     activeStep = state.activeStep,
-                    isPasscodeAlreadySet = state.hasPasscode,
+                    intention = state.intention,
                 )
                 PasscodeView(
                     restart = remember(viewModel) {
@@ -155,7 +163,7 @@ internal fun PasscodeScreen(
             Spacer(modifier = Modifier.height(8.dp))
 
             PasscodeForgotButton(
-                hasPassCode = state.hasPasscode,
+                intention = state.intention,
                 onForgotButton = onForgotButton,
             )
         }
@@ -242,7 +250,6 @@ private fun PasscodeScreenPreview() {
     PasscodeScreen(
         onForgotButton = {},
         onSkipButton = {},
-        onPasscodeConfirm = {},
-        onPasscodeRejected = {},
+        onPasscodeFlowComplete = {},
     )
 }

--- a/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/PasscodeNavigation.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/PasscodeNavigation.kt
@@ -12,28 +12,50 @@ package org.mifos.library.passcode
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 
 const val PASSCODE_SCREEN = "passcode_screen"
+
+enum class Intention(val value: String) {
+    CHANGE_PASSCODE("change_passcode"),
+    LOGIN_WITH_PASSCODE("login_with_passcode"),
+    CREATE_PASSCODE("create_passcode"),
+    ;
+
+    companion object {
+        fun fromValue(value: String): Intention =
+            Intention.entries.firstOrNull { it.value == value } ?: CREATE_PASSCODE
+    }
+}
+
+const val INTENTION = "intention"
+const val PASSCODE_ROUTE = "$PASSCODE_SCREEN?$INTENTION={$INTENTION}"
 
 fun NavGraphBuilder.passcodeRoute(
     onForgotButton: () -> Unit,
     onSkipButton: () -> Unit,
-    onPasscodeConfirm: (String) -> Unit,
-    onPasscodeRejected: () -> Unit,
+    onPasscodeFlowComplete: () -> Unit,
 ) {
     composable(
-        route = PASSCODE_SCREEN,
+        route = PASSCODE_ROUTE,
+        arguments = listOf(
+            navArgument(INTENTION) {
+                defaultValue = Intention.LOGIN_WITH_PASSCODE.value
+                type = NavType.StringType
+            },
+        ),
     ) {
         PasscodeScreen(
             onForgotButton = onForgotButton,
             onSkipButton = onSkipButton,
-            onPasscodeConfirm = onPasscodeConfirm,
-            onPasscodeRejected = onPasscodeRejected,
+            onPasscodeFlowComplete = onPasscodeFlowComplete,
         )
     }
 }
 
-fun NavController.navigateToPasscodeScreen(options: NavOptions? = null) {
-    navigate(PASSCODE_SCREEN, options)
+fun NavController.navigateToPasscodeScreen(options: NavOptions? = null, intention: Intention) {
+    val route = "$PASSCODE_SCREEN?$INTENTION=${intention.value}"
+    navigate(route, options)
 }

--- a/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/component/ChangePasscodeSuccessDialog.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/component/ChangePasscodeSuccessDialog.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+ */
+package org.mifos.library.passcode.component
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import mobile_wallet.libs.mifos_passcode.generated.resources.Res
+import mobile_wallet.libs.mifos_passcode.generated.resources.library_mifos_passcode_done
+import mobile_wallet.libs.mifos_passcode.generated.resources.library_mifos_passcode_passcode_changed_message
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun ChangePasscodeSuccessDialog(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+) {
+    if (visible) {
+        AlertDialog(
+            shape = MaterialTheme.shapes.large,
+            containerColor = Color.White,
+            title = {
+                Text(
+                    text = stringResource(Res.string.library_mifos_passcode_passcode_changed_message),
+                    color = Color.Black,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = onDismiss) {
+                    Text(
+                        text = stringResource(Res.string.library_mifos_passcode_done),
+                        color = Color.Black,
+                    )
+                }
+            },
+            onDismissRequest = onDismiss,
+        )
+    }
+}

--- a/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/component/PasscodeButton.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/component/PasscodeButton.kt
@@ -22,16 +22,17 @@ import mobile_wallet.libs.mifos_passcode.generated.resources.Res
 import mobile_wallet.libs.mifos_passcode.generated.resources.library_mifos_passcode_login_manually
 import mobile_wallet.libs.mifos_passcode.generated.resources.library_mifos_passcode_skip
 import org.jetbrains.compose.resources.stringResource
+import org.mifos.library.passcode.Intention
 import org.mifos.library.passcode.theme.forgotButtonStyle
 import org.mifos.library.passcode.theme.skipButtonStyle
 
 @Composable
 internal fun PasscodeSkipButton(
-    hasPassCode: Boolean,
+    intention: Intention,
     onSkipButton: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (!hasPassCode) {
+    if (intention == Intention.CREATE_PASSCODE) {
         Row(
             modifier = modifier
                 .fillMaxWidth()
@@ -52,11 +53,11 @@ internal fun PasscodeSkipButton(
 
 @Composable
 internal fun PasscodeForgotButton(
-    hasPassCode: Boolean,
+    intention: Intention,
     onForgotButton: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (hasPassCode) {
+    if (intention == Intention.LOGIN_WITH_PASSCODE) {
         Row(
             modifier = modifier
                 .fillMaxWidth()

--- a/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/component/PasscodeHeader.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/component/PasscodeHeader.kt
@@ -31,16 +31,18 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import mobile_wallet.libs.mifos_passcode.generated.resources.Res
 import mobile_wallet.libs.mifos_passcode.generated.resources.library_mifos_passcode_confirm_passcode
+import mobile_wallet.libs.mifos_passcode.generated.resources.library_mifos_passcode_create_new_passcode
 import mobile_wallet.libs.mifos_passcode.generated.resources.library_mifos_passcode_create_passcode
 import mobile_wallet.libs.mifos_passcode.generated.resources.library_mifos_passcode_enter_your_passcode
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.mifos.library.passcode.Intention
 import org.mifos.library.passcode.utility.Step
 
 @Composable
 internal fun PasscodeHeader(
     activeStep: Step,
-    isPasscodeAlreadySet: Boolean,
+    intention: Intention,
     modifier: Modifier = Modifier,
 ) {
     val transitionState = remember { MutableTransitionState(activeStep) }
@@ -76,42 +78,43 @@ internal fun PasscodeHeader(
     }
 
     Box(
-        modifier = modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.Center,
     ) {
-        Box(
-            modifier = Modifier.fillMaxWidth(),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (isPasscodeAlreadySet) {
+        when (activeStep) {
+            Step.Verify -> {
+                Text(
+                    text = stringResource(Res.string.library_mifos_passcode_enter_your_passcode),
+                    style = TextStyle(fontSize = 20.sp),
+                )
+            }
+
+            Step.Create -> {
                 Text(
                     modifier = Modifier
                         .offset(x = xTransitionHeader1.x.dp)
                         .alpha(alpha = alphaHeader1)
                         .scale(scale = scaleHeader1),
-                    text = stringResource(Res.string.library_mifos_passcode_enter_your_passcode),
+                    text = if (intention == Intention.CHANGE_PASSCODE) {
+                        stringResource(Res.string.library_mifos_passcode_create_new_passcode)
+                    } else {
+                        stringResource(
+                            Res.string.library_mifos_passcode_create_passcode,
+                        )
+                    },
                     style = TextStyle(fontSize = 20.sp),
                 )
-            } else {
-                if (activeStep == Step.Create) {
-                    Text(
-                        modifier = Modifier
-                            .offset(x = xTransitionHeader1.x.dp)
-                            .alpha(alpha = alphaHeader1)
-                            .scale(scale = scaleHeader1),
-                        text = stringResource(Res.string.library_mifos_passcode_create_passcode),
-                        style = TextStyle(fontSize = 20.sp),
-                    )
-                } else if (activeStep == Step.Confirm) {
-                    Text(
-                        modifier = Modifier
-                            .offset(x = xTransitionHeader2.x.dp)
-                            .alpha(alpha = alphaHeader2)
-                            .scale(scale = scaleHeader2),
-                        text = stringResource(Res.string.library_mifos_passcode_confirm_passcode),
-                        style = TextStyle(fontSize = 20.sp),
-                    )
-                }
+            }
+
+            Step.Confirm -> {
+                Text(
+                    modifier = Modifier
+                        .offset(x = xTransitionHeader2.x.dp)
+                        .alpha(alpha = alphaHeader2)
+                        .scale(scale = scaleHeader2),
+                    text = stringResource(Res.string.library_mifos_passcode_confirm_passcode),
+                    style = TextStyle(fontSize = 20.sp),
+                )
             }
         }
     }
@@ -120,5 +123,8 @@ internal fun PasscodeHeader(
 @Preview
 @Composable
 private fun PasscodeHeaderPreview() {
-    PasscodeHeader(activeStep = Step.Create, isPasscodeAlreadySet = true)
+    PasscodeHeader(
+        activeStep = Step.Verify,
+        intention = Intention.LOGIN_WITH_PASSCODE,
+    )
 }

--- a/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/component/PasscodeStepIndicator.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/component/PasscodeStepIndicator.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.library.passcode.theme.blueTint
 import org.mifos.library.passcode.utility.Constants.STEPS_COUNT
 import org.mifos.library.passcode.utility.Step
@@ -30,30 +31,38 @@ internal fun PasscodeStepIndicator(
     activeStep: Step,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(
-            space = 6.dp,
-            alignment = Alignment.CenterHorizontally,
-        ),
-    ) {
-        repeat(STEPS_COUNT) { step ->
-            val isActiveStep = step <= activeStep.index
-            val stepColor =
-                animateColorAsState(if (isActiveStep) blueTint else Color.Gray, label = "")
+    if (activeStep != Step.Verify) {
+        Row(
+            modifier = modifier,
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(
+                space = 6.dp,
+                alignment = Alignment.CenterHorizontally,
+            ),
+        ) {
+            repeat(STEPS_COUNT) { step ->
+                val isActiveStep = step + 1 == activeStep.index
+                val stepColor =
+                    animateColorAsState(if (isActiveStep) blueTint else Color.Gray, label = "")
 
-            Box(
-                modifier = Modifier
-                    .size(
-                        width = 72.dp,
-                        height = 4.dp,
-                    )
-                    .background(
-                        color = stepColor.value,
-                        shape = MaterialTheme.shapes.medium,
-                    ),
-            )
+                Box(
+                    modifier = Modifier
+                        .size(
+                            width = 72.dp,
+                            height = 4.dp,
+                        )
+                        .background(
+                            color = stepColor.value,
+                            shape = MaterialTheme.shapes.medium,
+                        ),
+                )
+            }
         }
     }
+}
+
+@Preview
+@Composable
+fun PasscodeStepIndicatorPreview() {
+    PasscodeStepIndicator(activeStep = Step.Confirm)
 }

--- a/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/utility/Step.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/utility/Step.kt
@@ -10,6 +10,7 @@
 package org.mifos.library.passcode.utility
 
 enum class Step(var index: Int) {
-    Create(0),
-    Confirm(1),
+    Verify(0),
+    Create(1),
+    Confirm(2),
 }

--- a/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/viewmodels/PasscodeViewModel.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/org/mifos/library/passcode/viewmodels/PasscodeViewModel.kt
@@ -14,6 +14,8 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.mifos.library.passcode.INTENTION
+import org.mifos.library.passcode.Intention
 import org.mifos.library.passcode.utility.Step
 import org.mifospay.core.common.Parcelable
 import org.mifospay.core.common.Parcelize
@@ -25,15 +27,37 @@ private const val PASSCODE_LENGTH = 4
 
 class PasscodeViewModel(
     private val passcodeRepository: PasscodeManager,
-    savedStateHandle: SavedStateHandle,
+    private val savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<PasscodeState, PasscodeEvent, PasscodeAction>(
     initialState = savedStateHandle[KEY_STATE] ?: PasscodeState(),
 ) {
+    private var verifyPasscode: StringBuilder = StringBuilder()
     private var createPasscode: StringBuilder = StringBuilder()
     private var confirmPasscode: StringBuilder = StringBuilder()
 
     init {
         observePasscodeRepository()
+        getIntention()
+    }
+
+    private fun getIntention() {
+        mutableStateFlow.update {
+            it.copy(
+                intention = savedStateHandle.get<String>(INTENTION)
+                    ?.let(Intention::fromValue)
+                    ?: Intention.LOGIN_WITH_PASSCODE,
+            )
+        }
+        if (
+            state.intention == Intention.CREATE_PASSCODE ||
+            (state.intention == Intention.CHANGE_PASSCODE && !state.hasPasscode) // in case if user have skipped setting the passcode initially, then the "Change passcode" button should directly allow him to create a new passcode
+        ) {
+            mutableStateFlow.update {
+                it.copy(
+                    activeStep = Step.Create,
+                )
+            }
+        }
     }
 
     private fun observePasscodeRepository() {
@@ -42,7 +66,6 @@ class PasscodeViewModel(
                 mutableStateFlow.update {
                     it.copy(
                         hasPasscode = hasPasscode,
-                        isPasscodeAlreadySet = hasPasscode,
                     )
                 }
             }
@@ -57,14 +80,27 @@ class PasscodeViewModel(
             is PasscodeAction.TogglePasscodeVisibility -> togglePasscodeVisibility()
             is PasscodeAction.Restart -> restart()
             is PasscodeAction.Internal.ProcessCompletedPasscode -> processCompletedPasscode()
+            PasscodeAction.DismissChangePasscodeSuccessDialog -> onDismissChangePasscodeSuccessDialog()
+            PasscodeAction.SkipPasscodeSetup -> onSkipPasscodeSetup()
         }
+    }
+
+    private fun onSkipPasscodeSetup() {
+        viewModelScope.launch {
+            passcodeRepository.setSkippedPasscodeSetup(true)
+        }
+        sendEvent(PasscodeEvent.PasscodeSetupSkipped)
     }
 
     private fun enterKey(key: String) {
         if (state.filledDots >= PASSCODE_LENGTH) return
 
-        val currentPasscode =
-            if (state.activeStep == Step.Create) createPasscode else confirmPasscode
+        val currentPasscode = when (state.activeStep) {
+            Step.Verify -> verifyPasscode
+            Step.Create -> createPasscode
+            Step.Confirm -> confirmPasscode
+        }
+
         currentPasscode.append(key)
 
         mutableStateFlow.update {
@@ -82,8 +118,11 @@ class PasscodeViewModel(
     }
 
     private fun deleteKey() {
-        val currentPasscode =
-            if (state.activeStep == Step.Create) createPasscode else confirmPasscode
+        val currentPasscode = when (state.activeStep) {
+            Step.Verify -> verifyPasscode
+            Step.Create -> createPasscode
+            Step.Confirm -> confirmPasscode
+        }
         if (currentPasscode.isNotEmpty()) {
             currentPasscode.deleteAt(currentPasscode.length - 1)
             mutableStateFlow.update {
@@ -96,11 +135,12 @@ class PasscodeViewModel(
     }
 
     private fun deleteAllKeys() {
-        if (state.activeStep == Step.Create) {
-            createPasscode.clear()
-        } else {
-            confirmPasscode.clear()
+        when (state.activeStep) {
+            Step.Verify -> verifyPasscode.clear()
+            Step.Create -> createPasscode.clear()
+            Step.Confirm -> confirmPasscode.clear()
         }
+
         mutableStateFlow.update {
             it.copy(
                 currentPasscodeInput = "",
@@ -120,22 +160,49 @@ class PasscodeViewModel(
     private fun processCompletedPasscode() {
         viewModelScope.launch {
             when {
-                state.isPasscodeAlreadySet -> validateExistingPasscode()
-                state.activeStep == Step.Create -> moveToConfirmStep()
-                else -> validateNewPasscode()
+                state.intention == Intention.CREATE_PASSCODE && state.activeStep == Step.Create -> moveToConfirmStep()
+                state.intention == Intention.CREATE_PASSCODE && state.activeStep == Step.Confirm -> validateAndSavePasscode()
+
+                state.intention == Intention.LOGIN_WITH_PASSCODE -> validateExistingPasscode()
+
+                state.intention == Intention.CHANGE_PASSCODE && state.activeStep == Step.Verify -> {
+                    validateExistingPasscode()
+                }
+
+                state.intention == Intention.CHANGE_PASSCODE && state.activeStep == Step.Create -> moveToConfirmStep()
+                state.intention == Intention.CHANGE_PASSCODE && state.activeStep == Step.Confirm -> validateAndSavePasscode()
             }
         }
     }
 
+    private fun onDismissChangePasscodeSuccessDialog() {
+        mutableStateFlow.update { it.copy(isChangePasscodeSuccessful = true) }
+        sendEvent(PasscodeEvent.PasscodeConfirmed)
+    }
+
     private suspend fun validateExistingPasscode() {
         val savedPasscode = passcodeRepository.getPasscode.first()
-        if (savedPasscode == createPasscode.toString()) {
-            sendEvent(PasscodeEvent.PasscodeConfirmed(createPasscode.toString()))
-            createPasscode.clear()
+        if (savedPasscode == verifyPasscode.toString()) {
+            if (state.intention == Intention.CHANGE_PASSCODE && state.activeStep == Step.Verify) {
+                moveToCreateStep()
+            } else {
+                sendEvent(PasscodeEvent.PasscodeConfirmed)
+            }
+            verifyPasscode.clear()
         } else {
             sendEvent(PasscodeEvent.PasscodeRejected)
         }
         mutableStateFlow.update { it.copy(currentPasscodeInput = "") }
+    }
+
+    private fun moveToCreateStep() {
+        mutableStateFlow.update {
+            it.copy(
+                activeStep = Step.Create,
+                filledDots = 0,
+                currentPasscodeInput = "",
+            )
+        }
     }
 
     private fun moveToConfirmStep() {
@@ -148,10 +215,16 @@ class PasscodeViewModel(
         }
     }
 
-    private suspend fun validateNewPasscode() {
+    private suspend fun validateAndSavePasscode() {
         if (createPasscode.toString() == confirmPasscode.toString()) {
             passcodeRepository.savePasscode(confirmPasscode.toString())
-            sendEvent(PasscodeEvent.PasscodeConfirmed(confirmPasscode.toString()))
+
+            if (state.intention == Intention.CHANGE_PASSCODE) {
+                mutableStateFlow.update { it.copy(isChangePasscodeSuccessful = true) }
+            } else {
+                sendEvent(PasscodeEvent.PasscodeConfirmed)
+            }
+
             resetState()
         } else {
             sendEvent(PasscodeEvent.PasscodeRejected)
@@ -161,11 +234,12 @@ class PasscodeViewModel(
 
     private fun resetState() {
         mutableStateFlow.update {
-            PasscodeState(
-                hasPasscode = it.hasPasscode,
-                isPasscodeAlreadySet = it.isPasscodeAlreadySet,
+            it.copy(
+                currentPasscodeInput = "",
+                filledDots = 0,
             )
         }
+        verifyPasscode.clear()
         createPasscode.clear()
         confirmPasscode.clear()
     }
@@ -174,16 +248,18 @@ class PasscodeViewModel(
 @Parcelize
 data class PasscodeState(
     val hasPasscode: Boolean = false,
-    val activeStep: Step = Step.Create,
+    val activeStep: Step = Step.Verify,
     val filledDots: Int = 0,
     val passcodeVisible: Boolean = false,
     val currentPasscodeInput: String = "",
-    val isPasscodeAlreadySet: Boolean = false,
+    val intention: Intention = Intention.LOGIN_WITH_PASSCODE,
+    val isChangePasscodeSuccessful: Boolean = false,
 ) : Parcelable
 
 sealed class PasscodeEvent {
-    data class PasscodeConfirmed(val passcode: String) : PasscodeEvent()
+    data object PasscodeConfirmed : PasscodeEvent()
     data object PasscodeRejected : PasscodeEvent()
+    data object PasscodeSetupSkipped : PasscodeEvent()
 }
 
 sealed class PasscodeAction {
@@ -192,6 +268,8 @@ sealed class PasscodeAction {
     data object DeleteAllKeys : PasscodeAction()
     data object TogglePasscodeVisibility : PasscodeAction()
     data object Restart : PasscodeAction()
+    data object DismissChangePasscodeSuccessDialog : PasscodeAction()
+    data object SkipPasscodeSetup : PasscodeAction()
 
     sealed class Internal : PasscodeAction() {
         data object ProcessCompletedPasscode : Internal()

--- a/libs/mifos-passcode/src/commonMain/kotlin/proto/org/mifos/library/passcode/data/PasscodeManager.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/proto/org/mifos/library/passcode/data/PasscodeManager.kt
@@ -33,13 +33,24 @@ class PasscodeManager(
         initialValue = false,
     )
 
+    val hasSkippedPasscodeSetup = source.hasSkippedPasscodeSetup.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false,
+    )
+
     suspend fun savePasscode(passcode: String) {
         source.updatePasscodeSettings(
             PasscodePreferencesProto(
                 passcode = passcode,
                 hasPasscode = passcode.isNotEmpty(),
+                hasSkippedPasscodeSetup = false,
             ),
         )
+    }
+
+    suspend fun setSkippedPasscodeSetup(skipped: Boolean) {
+        source.updateSkippedPasscodeSetup(skipped)
     }
 
     suspend fun clearPasscode() {

--- a/libs/mifos-passcode/src/commonMain/kotlin/proto/org/mifos/library/passcode/data/PasscodePreferencesDataSource.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/proto/org/mifos/library/passcode/data/PasscodePreferencesDataSource.kt
@@ -42,11 +42,20 @@ class PasscodePreferencesDataSource(
 
     val passcode = passcodeSettings.map { it.passcode }
     val hasPasscode = passcodeSettings.map { it.hasPasscode }
+    val hasSkippedPasscodeSetup = passcodeSettings.map { it.hasSkippedPasscodeSetup }
 
     suspend fun updatePasscodeSettings(passcodePreferences: PasscodePreferencesProto) {
         withContext(dispatcher) {
             settings.putPasscodePreference(passcodePreferences)
             passcodeSettings.value = passcodePreferences
+        }
+    }
+
+    suspend fun updateSkippedPasscodeSetup(skipped: Boolean) {
+        withContext(dispatcher) {
+            val updated = passcodeSettings.value.copy(hasSkippedPasscodeSetup = skipped)
+            settings.putPasscodePreference(updated)
+            passcodeSettings.value = updated
         }
     }
 

--- a/libs/mifos-passcode/src/commonMain/kotlin/proto/org/mifos/library/passcode/di/PreferenceModule.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/proto/org/mifos/library/passcode/di/PreferenceModule.kt
@@ -17,7 +17,7 @@ import proto.org.mifos.library.passcode.data.PasscodeManager
 import proto.org.mifos.library.passcode.data.PasscodePreferencesDataSource
 
 val PasscodePreferenceModule = module {
-    factory<Settings> { Settings() }
-    factory { PasscodePreferencesDataSource(get(), get(named(MifosDispatchers.IO.name))) }
-    factory { PasscodeManager(get(), get(named(MifosDispatchers.Unconfined.name))) }
+    single<Settings> { Settings() }
+    single { PasscodePreferencesDataSource(get(), get(named(MifosDispatchers.IO.name))) }
+    single { PasscodeManager(get(), get(named(MifosDispatchers.IO.name))) }
 }

--- a/libs/mifos-passcode/src/commonMain/kotlin/proto/org/mifos/library/passcode/model/PasscodePreferencesProto.kt
+++ b/libs/mifos-passcode/src/commonMain/kotlin/proto/org/mifos/library/passcode/model/PasscodePreferencesProto.kt
@@ -15,8 +15,13 @@ import kotlinx.serialization.Serializable
 data class PasscodePreferencesProto(
     val passcode: String,
     val hasPasscode: Boolean,
+    val hasSkippedPasscodeSetup: Boolean = false,
 ) {
     companion object {
-        val DEFAULT = PasscodePreferencesProto(passcode = "", hasPasscode = false)
+        val DEFAULT = PasscodePreferencesProto(
+            passcode = "",
+            hasPasscode = false,
+            hasSkippedPasscodeSetup = false,
+        )
     }
 }


### PR DESCRIPTION
Jira Task: [324](https://mifosforge.jira.com/browse/MW-324?atlOrigin=eyJpIjoiNmRmYTNkNWZmNDYwNDQ1NmJlYWY0NzBkZWM3NmVjMWYiLCJwIjoiaiJ9)

## Screen recording
Verify old passcode → Create → Confirm → Success dialog → Back to Settings.

https://github.com/user-attachments/assets/72e528fc-0d1d-437c-99ac-ebd534f8ae90



## Description
Summary
- Fix “Change Passcode” not triggering.
- Implement full flow: verify current passcode → create new passcode → confirm passcode → save passcode → success dialog → return to Settings.

### Changes made ->
- Passcode screen is outside Main_Graph; pass rootNavController to MifosNavHost to support cross-graph navigation.
- Navigation arg: Added INTENTION query parameter (String) and Intention enum (CHANGE_PASSCODE, LOGIN_WITH_PASSCODE, CREATE_PASSCODE) to drive passcode screen state.
- INTENTION defaults to LOGIN_WITH_PASSCODE because rootNavGraph uses PASSCODE_GRAPH startDestination (not PASSCODE_SCREEN).

### Other related/connected minor changes ->
- Fix navigating to home screen even after entering wrong passcode
- Fix navigating to home screen even when "Forgot Passcode? Login manually" button is clicked
- For both of the fixes only single line changes are made in MifosNavHost.