### PR TITLE
fix(workflows): correct sync directory workflow for scheduled runs

### DIFF
--- a/.github/workflows/sync-dirs.yaml
+++ b/.github/workflows/sync-dirs.yaml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   sync-directories:
+    if: github.repository != 'openMF/kmp-project-template'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -31,7 +32,8 @@ jobs:
 
       - name: Add upstream remote and fetch
         run: |
-          git remote add upstream ${{ inputs.upstream }} || true
+          UPSTREAM="${{ inputs.upstream || 'https://github.com/openMF/kmp-project-template.git' }}"
+          git remote add upstream "$UPSTREAM" || true
           git fetch upstream || exit 1
 
       - name: Check upstream/dev exists

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,6 @@ plugins {
     alias(libs.plugins.module.graph) apply true
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.spotless) apply false
-    alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.version.catalog.linter) apply true
     // Multiplatform plugins
     alias(libs.plugins.jetbrainsCompose) apply false


### PR DESCRIPTION
## Issue Fix
Jira Task: [MW-329](https://mifosforge.jira.com/browse/MW-329)

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->

## Description
Summary of changes:
- Added `upstream` address in shell command which was not being passed correctly during scheduled runs
- Added `if` statement for skipping `sync-dirs` workflow runs in the `kmp-project-template`

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.


[MW-329]: https://mifosforge.jira.com/browse/MW-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow synchronization with repository-specific handling and improved upstream URL configuration with fallback support
  * Removed ktlint plugin from build configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->