### PR TITLE
fix(history): Fetch transactions only for selected account

### DIFF
--- a/core/data/src/commonMain/kotlin/org/mifospay/core/data/repository/SelfServiceRepository.kt
+++ b/core/data/src/commonMain/kotlin/org/mifospay/core/data/repository/SelfServiceRepository.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.Flow
 import org.mifospay.core.common.DataState
 import org.mifospay.core.model.account.Account
 import org.mifospay.core.model.account.AccountContent
-import org.mifospay.core.model.account.AccountsWithTransactions
 import org.mifospay.core.model.beneficiary.Beneficiary
 import org.mifospay.core.model.beneficiary.BeneficiaryPayload
 import org.mifospay.core.model.beneficiary.BeneficiaryUpdatePayload
@@ -42,11 +41,6 @@ interface SelfServiceRepository {
     fun getSelfAccounts(clientId: Long): Flow<DataState<List<Account>>>
 
     fun getBeneficiaryList(): Flow<DataState<List<Beneficiary>>>
-
-    fun getActiveAccountsWithTransactions(
-        clientId: Long,
-        limit: Int,
-    ): Flow<DataState<AccountsWithTransactions>>
 
     fun getActiveAccountsWithTransactionsPerAccount(
         clientId: Long,

--- a/core/data/src/commonMain/kotlin/org/mifospay/core/data/repositoryImpl/SelfServiceRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/mifospay/core/data/repositoryImpl/SelfServiceRepositoryImpl.kt
@@ -44,7 +44,6 @@ import org.mifospay.core.data.util.Constants
 import org.mifospay.core.data.util.parseMifosError
 import org.mifospay.core.model.account.Account
 import org.mifospay.core.model.account.AccountContent
-import org.mifospay.core.model.account.AccountsWithTransactions
 import org.mifospay.core.model.beneficiary.Beneficiary
 import org.mifospay.core.model.beneficiary.BeneficiaryPayload
 import org.mifospay.core.model.beneficiary.BeneficiaryUpdatePayload
@@ -140,29 +139,6 @@ class SelfServiceRepositoryImpl(
         }.flowOn(dispatcher)
     }
 
-    // TODO:: Optimize below functions
-    @OptIn(ExperimentalCoroutinesApi::class)
-    override fun getActiveAccountsWithTransactions(
-        clientId: Long,
-        limit: Int,
-    ): Flow<DataState<AccountsWithTransactions>> {
-        val accounts = apiManager.clientsApi
-            .getAccounts(clientId, Constants.SAVINGS)
-            .map { entity -> entity.savingsAccounts.filter { it.status.active } }
-            .map { it.toAccount() }
-            .flowOn(dispatcher)
-
-        val transactions = accounts
-            .map { list -> list.map { it.id } }
-            .flatMapLatest {
-                getTransactions(it, limit)
-            }
-
-        return accounts.combine(transactions) { accountList, transaction ->
-            AccountsWithTransactions(accountList, transaction)
-        }.asDataStateFlow(parseMifosError)
-    }
-
     override fun getActiveAccountsWithTransactionsPerAccount(
         clientId: Long,
         limit: Int?,
@@ -182,7 +158,7 @@ class SelfServiceRepositoryImpl(
             combine(flows) { pairs ->
                 pairs.toMap()
             }
-        }.asDataStateFlow(parseMifosError)
+        }.asDataStateFlow()
     }
 
     override fun getActiveAccounts(
@@ -193,7 +169,7 @@ class SelfServiceRepositoryImpl(
             .map { entity -> entity.savingsAccounts.filter { it.status.active } }
             .map { it.toAccount() }
             .flowOn(dispatcher)
-            .asDataStateFlow(parseMifosError)
+            .asDataStateFlow()
     }
 
     override fun getActiveAccountsWithAccountTransferTemplate(
@@ -226,7 +202,7 @@ class SelfServiceRepositoryImpl(
                         )
                     }
                 }
-        }.asDataStateFlow(parseMifosError)
+        }.asDataStateFlow()
     }
 
     override fun getTransactions(accountId: List<Long>, limit: Int?): Flow<List<Transaction>> {
@@ -252,7 +228,7 @@ class SelfServiceRepositoryImpl(
                 }
             }
             .flowOn(dispatcher)
-            .asDataStateFlow(parseMifosError)
+            .asDataStateFlow()
     }
 
     override fun getAccountsTransactions(
@@ -271,11 +247,11 @@ class SelfServiceRepositoryImpl(
                         .filter { transactions -> transactions.isNotEmpty() }
                 }
             }
-            .asDataStateFlow(parseMifosError)
+            .asDataStateFlow()
     }
 
     override fun getBeneficiaryList(): Flow<DataState<List<Beneficiary>>> {
-        return apiManager.beneficiaryApi.beneficiaryList().asDataStateFlow(parseMifosError).flowOn(dispatcher)
+        return apiManager.beneficiaryApi.beneficiaryList().asDataStateFlow().flowOn(dispatcher)
     }
 
     override suspend fun createBeneficiary(

--- a/feature/history/src/commonMain/composeResources/values/strings.xml
+++ b/feature/history/src/commonMain/composeResources/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="feature_history_credits">Credits</string>
     <string name="feature_history_debits">Debits</string>
     <string name="feature_history_loading">Loading</string>
+    <string name="feature_history_no_account">No accounts found</string>
     <string name="feature_history_no_transactions_found">No transactions found</string>
     <string name="feature_history_specific_transactions_history">Specific Transactions History</string>
     <string name="feature_history_transaction_details">Transaction Details</string>

--- a/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryScreen.kt
+++ b/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -37,7 +36,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mobile_wallet.feature.history.generated.resources.Res
 import mobile_wallet.feature.history.generated.resources.feature_history_empty
 import mobile_wallet.feature.history.generated.resources.feature_history_empty_filter
-import mobile_wallet.feature.history.generated.resources.feature_history_error
 import mobile_wallet.feature.history.generated.resources.feature_history_error_oops
 import mobile_wallet.feature.history.generated.resources.feature_history_filter_content_desc
 import mobile_wallet.feature.history.generated.resources.feature_history_header_account
@@ -96,7 +94,7 @@ internal fun HistoryScreenContent(
             is HistoryState.ViewState.Error -> {
                 EmptyContentScreen(
                     title = stringResource(Res.string.feature_history_error_oops),
-                    subTitle = stringResource(Res.string.feature_history_error),
+                    subTitle = stringResource(state.viewState.message),
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues),
@@ -120,12 +118,12 @@ internal fun HistoryScreenContent(
                 ) {
                     HistoryScreenHeader(
                         accountNo = state.selectedAccount?.number ?: "",
-                        selectedTransactionType = state.transactionType,
+                        selectedTransactionType = state.selectedTransactionType,
                         onFilterClick = {
                             onAction(HistoryAction.OnFilterClick)
                         },
                     )
-                    if (state.filteredEmpty) {
+                    if (state.viewState.list.isEmpty()) {
                         EmptyContentScreen(
                             title = stringResource(Res.string.feature_history_error_oops),
                             subTitle = stringResource(Res.string.feature_history_empty_filter),
@@ -142,14 +140,14 @@ internal fun HistoryScreenContent(
                 }
                 if (state.showFilter) {
                     TransactionFilterBottomSheet(
-                        selectedAccount = state.currentSelectedAccount,
+                        selectedAccount = state.selectedAccount,
                         accounts = state.accounts,
-                        selectedTransactionType = state.currentSelectedTransactionType,
+                        selectedTransactionType = state.selectedTransactionType,
                         onAccountSelected = {
                             onAction(HistoryAction.SetSelectedAccount(it))
                         },
                         onTransactionTypeSelected = {
-                            onAction(HistoryAction.SetFilter(it))
+                            onAction(HistoryAction.SetTransactionType(it))
                         },
                         onClearFilters = {
                             onAction(HistoryAction.ClearFilters)

--- a/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryViewModel.kt
@@ -13,6 +13,10 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
+import mobile_wallet.feature.history.generated.resources.Res
+import mobile_wallet.feature.history.generated.resources.feature_history_error
+import mobile_wallet.feature.history.generated.resources.feature_history_no_account
+import org.jetbrains.compose.resources.StringResource
 import org.mifospay.core.common.DataState
 import org.mifospay.core.data.repository.SelfServiceRepository
 import org.mifospay.core.datastore.UserPreferencesRepository
@@ -20,34 +24,28 @@ import org.mifospay.core.model.account.Account
 import org.mifospay.core.model.savingsaccount.Transaction
 import org.mifospay.core.model.savingsaccount.TransactionType
 import org.mifospay.core.ui.utils.BaseViewModel
-import org.mifospay.feature.history.HistoryAction.Internal.TransactionsLoaded
 
 class HistoryViewModel(
     private val preferencesRepository: UserPreferencesRepository,
-    repository: SelfServiceRepository,
+    private val repository: SelfServiceRepository,
 ) : BaseViewModel<HistoryState, HistoryEvent, HistoryAction>(
     initialState = run {
         val clientId = requireNotNull(preferencesRepository.clientId.value)
         HistoryState(
             clientId = clientId,
             viewState = HistoryState.ViewState.Loading,
-            transactionType = TransactionType.OTHER,
         )
     },
 ) {
     init {
-        repository.getActiveAccountsWithTransactionsPerAccount(state.clientId, null).onEach {
-            sendAction(TransactionsLoaded(it))
-        }.launchIn(viewModelScope)
+        loadActiveAccounts()
     }
 
     override fun handleAction(action: HistoryAction) {
         when (action) {
-            is HistoryAction.SetFilter -> handleSetFilter(action.filter)
+            is HistoryAction.SetTransactionType -> handleSetTransactionType(action.filter)
 
             is HistoryAction.ViewTransaction -> handleViewTransaction(action.transferId)
-
-            is TransactionsLoaded -> handleTransactionLoaded(action)
 
             is HistoryAction.OnFilterClick -> handleFilterClick()
 
@@ -59,37 +57,116 @@ class HistoryViewModel(
         }
     }
 
+    private fun loadTransactions(accountId: Long) {
+        repository.getTransactions(accountId, null).onEach { result ->
+            when (result) {
+                is DataState.Error -> {
+                    mutableStateFlow.update {
+                        it.copy(viewState = HistoryState.ViewState.Error(Res.string.feature_history_error))
+                    }
+                }
+
+                DataState.Loading -> {
+                    mutableStateFlow.update {
+                        it.copy(viewState = HistoryState.ViewState.Loading)
+                    }
+                }
+
+                is DataState.Success -> {
+                    val transactions = result.data
+                    if (transactions.isNotEmpty()) {
+                        mutableStateFlow.update {
+                            it.copy(
+                                transactions = transactions,
+                                viewState = HistoryState.ViewState.Content(transactions),
+                            )
+                        }
+                        applyFilter(transactions)
+                    } else {
+                        mutableStateFlow.update {
+                            it.copy(
+                                transactions = transactions,
+                                viewState = HistoryState.ViewState.Empty,
+                            )
+                        }
+                    }
+                }
+            }
+        }.launchIn(viewModelScope)
+    }
+
+    private fun loadActiveAccounts() {
+        repository.getActiveAccounts(state.clientId).onEach { result ->
+            when (result) {
+                is DataState.Error -> {
+                    mutableStateFlow.update {
+                        it.copy(viewState = HistoryState.ViewState.Error(Res.string.feature_history_error))
+                    }
+                }
+
+                DataState.Loading -> {
+                    mutableStateFlow.update {
+                        it.copy(viewState = HistoryState.ViewState.Loading)
+                    }
+                }
+
+                is DataState.Success -> {
+                    val accounts = result.data
+                    if (accounts.isNotEmpty()) {
+                        loadTransactions(accounts.first().id)
+                        mutableStateFlow.update { state ->
+                            state.copy(
+                                accounts = accounts,
+                                selectedAccount = accounts.firstOrNull(),
+                            )
+                        }
+                    } else {
+                        mutableStateFlow.update {
+                            it.copy(viewState = HistoryState.ViewState.Error(Res.string.feature_history_no_account))
+                        }
+                    }
+                }
+            }
+        }.launchIn(viewModelScope)
+    }
+
     private fun handleClearFilters() {
         mutableStateFlow.update {
             it.copy(
-                currentSelectedTransactionType = TransactionType.OTHER,
+                selectedTransactionType = TransactionType.OTHER,
                 showFilter = false,
             )
         }
         applyFilter(state.transactions)
     }
+
     private fun handleApplyFilterClick() {
-        val transactions = state.transactionsWithAccounts[state.currentSelectedAccount]
         mutableStateFlow.update {
             it.copy(
                 showFilter = false,
-                filteredEmpty = transactions.isNullOrEmpty(),
-                selectedAccount = state.currentSelectedAccount,
-                transactions = transactions ?: emptyList(),
             )
         }
-        applyFilter(transactions)
+        val accountIdOfLoadedTransactions: Long? =
+            if (state.transactions.isNotEmpty()) state.transactions.first().accountId else null
+
+        if (state.selectedAccount?.id == accountIdOfLoadedTransactions) {
+            applyFilter(state.transactions)
+        } else {
+            state.selectedAccount?.let { account ->
+                loadTransactions(account.id)
+            }
+        }
     }
 
-    private fun handleSetFilter(filter: TransactionType) {
+    private fun handleSetTransactionType(filter: TransactionType) {
         mutableStateFlow.update {
-            it.copy(currentSelectedTransactionType = filter)
+            it.copy(selectedTransactionType = filter)
         }
     }
 
     private fun handleSetSelectedAccount(account: Account) {
         mutableStateFlow.update {
-            it.copy(currentSelectedAccount = account)
+            it.copy(selectedAccount = account)
         }
     }
 
@@ -103,9 +180,9 @@ class HistoryViewModel(
         }
     }
 
-    private fun applyFilter(transactions: List<Transaction>?) {
-        val filter = state.currentSelectedTransactionType
-        val filteredTransactions = transactions?.filter {
+    private fun applyFilter(transactions: List<Transaction>) {
+        val filter = state.selectedTransactionType
+        val filteredTransactions = transactions.filter {
             if (filter == TransactionType.OTHER) {
                 true
             } else {
@@ -115,46 +192,8 @@ class HistoryViewModel(
 
         mutableStateFlow.update {
             it.copy(
-                transactionType = filter,
-                viewState = HistoryState.ViewState.Content(filteredTransactions ?: emptyList()),
-                filteredEmpty = filteredTransactions.isNullOrEmpty(),
+                viewState = HistoryState.ViewState.Content(filteredTransactions),
             )
-        }
-    }
-
-    private fun handleTransactionLoaded(action: TransactionsLoaded) {
-        when (action.result) {
-            is DataState.Loading -> {
-                mutableStateFlow.update {
-                    it.copy(viewState = HistoryState.ViewState.Loading)
-                }
-            }
-
-            is DataState.Error -> {
-                val message = action.result.exception.message.toString()
-                mutableStateFlow.update {
-                    it.copy(viewState = HistoryState.ViewState.Error(message))
-                }
-            }
-
-            is DataState.Success -> {
-                val result = action.result.data
-                val firstAccount = result.keys.first()
-                mutableStateFlow.update {
-                    it.copy(
-                        transactionsWithAccounts = result,
-                        accounts = result.keys.toList(),
-                        selectedAccount = firstAccount,
-                        currentSelectedAccount = firstAccount,
-                        transactions = result[firstAccount] ?: emptyList(),
-                        viewState = if (action.result.data.isEmpty()) {
-                            HistoryState.ViewState.Empty
-                        } else {
-                            HistoryState.ViewState.Content(result[firstAccount] ?: emptyList())
-                        },
-                    )
-                }
-            }
         }
     }
 }
@@ -162,20 +201,16 @@ class HistoryViewModel(
 data class HistoryState(
     val clientId: Long,
     val viewState: ViewState,
-    val transactionType: TransactionType,
-    val currentSelectedTransactionType: TransactionType = TransactionType.OTHER,
+    val selectedTransactionType: TransactionType = TransactionType.OTHER,
     val transactions: List<Transaction> = emptyList(),
-    val transactionsWithAccounts: Map<Account, List<Transaction>> = emptyMap(),
     val accounts: List<Account> = emptyList(),
     val selectedAccount: Account? = null,
-    val currentSelectedAccount: Account? = null,
     val showFilter: Boolean = false,
-    val filteredEmpty: Boolean = false,
 ) {
     sealed interface ViewState {
         data object Loading : ViewState
         data object Empty : ViewState
-        data class Error(val message: String) : ViewState
+        data class Error(val message: StringResource) : ViewState
         data class Content(val list: List<Transaction>) : ViewState
     }
 }
@@ -185,14 +220,10 @@ sealed interface HistoryEvent {
 }
 
 sealed interface HistoryAction {
-    data class SetFilter(val filter: TransactionType) : HistoryAction
+    data class SetTransactionType(val filter: TransactionType) : HistoryAction
     data class ViewTransaction(val transferId: Long) : HistoryAction
     data object OnFilterClick : HistoryAction
     data class SetSelectedAccount(val account: Account) : HistoryAction
     data object OnApplyFilterClick : HistoryAction
     data object ClearFilters : HistoryAction
-
-    sealed interface Internal : HistoryAction {
-        data class TransactionsLoaded(val result: DataState<Map<Account, List<Transaction>>>) : Internal
-    }
 }


### PR DESCRIPTION
Jira Task: [MW-326](https://mifosforge.jira.com/browse/MW-326?atlOrigin=eyJpIjoiN2Y2MGQwNjIzODI1NGI4OWEzYzNhMTAwOTFjZGQ4NGMiLCJwIjoiaiJ9)

## Description
Before HistoryViewModel was fetching transactions for all the accounts initially. 
Now it fetches transactions only for the selected account.
Behavior of the app on screen doesn't change. 
Second savings account of user have 4 transactions on 28 feb 2026. (first savings account have no transactions on 28 feb 2026)

## Screen recording
### Before
Those 4 transactions of not selected account are fetched initially.

https://github.com/user-attachments/assets/48f63359-fd86-4a84-a46e-d95894826976

### After
Those 4 transactions of not selected account are fetched after selecting that account.

https://github.com/user-attachments/assets/e4dcf46c-5e10-4c74-9f32-84968ac1dd2b




[MW-326]: https://mifosforge.jira.com/browse/MW-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * History now loads accounts first, then transactions for the selected account; filtering simplified.

* **UI / Behavior**
  * Header, filter sheet, and list/empty detection reflect selected account and selected transaction type.
  * Error state shows dynamic, context-aware messages.

* **Bug Fixes**
  * Shows "No accounts found" when there are no accounts.

* **Chores**
  * Reduced public surface: removed an account/transactions API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->