### PR TITLE
fix: remove product flavors from KMP library convention plugin

### DIFF
--- a/build-logic/convention/src/main/kotlin/KMPLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPLibraryConventionPlugin.kt
@@ -4,7 +4,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import org.mifospay.configureFlavors
 import org.mifospay.configureKotlinAndroid
 import org.mifospay.configureKotlinMultiplatform
 import org.mifospay.libs
@@ -25,7 +24,9 @@ class KMPLibraryConventionPlugin: Plugin<Project> {
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
                 defaultConfig.targetSdk = 34
-                configureFlavors(this)
+                // Note: Do NOT add configureFlavors here - KMP libraries should not have
+                // product flavors as it causes "android, android, android, android" resolution
+                // errors. Flavors should only be on the application module.
                 // The resource prefix is derived from the module name,
                 // so resources inside ":core:module1" must be prefixed with "core_module1_"
                 resourcePrefix = path


### PR DESCRIPTION
## Summary
- Remove `configureFlavors()` from `KMPLibraryConventionPlugin` to fix KMP dependency resolution errors

## Problem
When KMP library modules have product flavors (demo/prod) combined with build types (debug/release), it creates 4 Android variants. KMP sees these as 4 separate Android targets, causing dependency resolution to fail with:

```
KMP Dependencies Resolution Failure
Source set 'commonMain' couldn't resolve dependencies for all target platforms
Couldn't resolve dependency 'project :core:ui' in 'commonMain' for all target platforms.
The dependency should target platforms: [android, android, android, android, desktop, iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
Unresolved platforms: [android, android, android, android]
```

## Solution
Product flavors should only be configured on application modules (`cmp-android`), not on KMP library modules. This PR removes `configureFlavors(this)` from `KMPLibraryConventionPlugin.kt`.

## Test plan
- [x] Verify `./gradlew :core:ui:compileDebugKotlinAndroid` succeeds
- [x] Verify `./gradlew :cmp-shared:compileDebugKotlinAndroid` succeeds
- [x] Verify `./gradlew :cmp-android:assembleProdDebug` succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android resolution errors that affected Kotlin Multiplatform library modules during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->