### PR TITLE
fix(feature/accounts): make office name dynamic in AddEditBeneficiary…

### DIFF
--- a/core/data/src/commonMain/kotlin/org/mifospay/core/data/di/RepositoryModule.kt
+++ b/core/data/src/commonMain/kotlin/org/mifospay/core/data/di/RepositoryModule.kt
@@ -24,6 +24,7 @@ import org.mifospay.core.data.repository.InvoiceRepository
 import org.mifospay.core.data.repository.KycLevelRepository
 import org.mifospay.core.data.repository.LocalAssetRepository
 import org.mifospay.core.data.repository.NotificationRepository
+import org.mifospay.core.data.repository.OfficeRepository
 import org.mifospay.core.data.repository.RegistrationRepository
 import org.mifospay.core.data.repository.RunReportRepository
 import org.mifospay.core.data.repository.SavedCardRepository
@@ -45,6 +46,7 @@ import org.mifospay.core.data.repositoryImpl.InvoiceRepositoryImpl
 import org.mifospay.core.data.repositoryImpl.KycLevelRepositoryImpl
 import org.mifospay.core.data.repositoryImpl.LocalAssetRepositoryImpl
 import org.mifospay.core.data.repositoryImpl.NotificationRepositoryImpl
+import org.mifospay.core.data.repositoryImpl.OfficeRepositoryImpl
 import org.mifospay.core.data.repositoryImpl.RegistrationRepositoryImpl
 import org.mifospay.core.data.repositoryImpl.RunReportRepositoryImpl
 import org.mifospay.core.data.repositoryImpl.SavedCardRepositoryImpl
@@ -96,6 +98,7 @@ val RepositoryModule = module {
     }
     single<TwoFactorAuthRepository> { TwoFactorAuthRepositoryImpl(get(), get(ioDispatcher)) }
     single<UserRepository> { UserRepositoryImpl(get(), get(ioDispatcher)) }
+    single<OfficeRepository> { OfficeRepositoryImpl(get(), get(ioDispatcher)) }
 
     includes(platformModule)
     single<PlatformDependentDataModule> { getPlatformDataModule }

--- a/core/data/src/commonMain/kotlin/org/mifospay/core/data/repository/OfficeRepository.kt
+++ b/core/data/src/commonMain/kotlin/org/mifospay/core/data/repository/OfficeRepository.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+ */
+package org.mifospay.core.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import org.mifospay.core.common.DataState
+import org.mifospay.core.model.office.Office
+
+interface OfficeRepository {
+    fun getOffices(): Flow<DataState<List<Office>>>
+}

--- a/core/data/src/commonMain/kotlin/org/mifospay/core/data/repositoryImpl/OfficeRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/mifospay/core/data/repositoryImpl/OfficeRepositoryImpl.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+ */
+package org.mifospay.core.data.repositoryImpl
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.retryWhen
+import org.mifospay.core.common.DataState
+import org.mifospay.core.data.repository.OfficeRepository
+import org.mifospay.core.model.office.Office
+import org.mifospay.core.network.FineractApiManager
+
+class OfficeRepositoryImpl(
+    private val apiManager: FineractApiManager,
+    private val ioDispatcher: CoroutineDispatcher,
+) : OfficeRepository {
+    override fun getOffices(): Flow<DataState<List<Office>>> = flow {
+        emit(DataState.Loading)
+
+        apiManager.officeApi.getOffices()
+            .retryWhen { _, attempt ->
+                if (attempt < 3) {
+                    delay(1000L * (1 shl attempt.toInt()))
+                    true
+                } else {
+                    false
+                }
+            }
+            .collect { offices ->
+                emit(DataState.Success(offices))
+            }
+    }
+        .catch { exception ->
+            emit(DataState.Error(exception, null))
+        }
+        .flowOn(ioDispatcher)
+}

--- a/core/model/src/commonMain/kotlin/org/mifospay/core/model/office/Office.kt
+++ b/core/model/src/commonMain/kotlin/org/mifospay/core/model/office/Office.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+ */
+package org.mifospay.core.model.office
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Office(
+    val id: Long,
+    val name: String,
+    val nameDecorated: String? = null,
+    val externalId: String? = null,
+    val openingDate: List<Int>? = null,
+    val hierarchy: String? = null,
+)

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/FineractApiManager.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/FineractApiManager.kt
@@ -44,4 +44,6 @@ class FineractApiManager(
     val savingsAccountsApi by lazy { ktorfitClient.savingsAccountsApi }
 
     val standingInstructionApi by lazy { ktorfitClient.standingInstructionApi }
+
+    val officeApi by lazy { ktorfitClient.officeApi }
 }

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/KtorfitClient.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/KtorfitClient.kt
@@ -19,6 +19,7 @@ import org.mifospay.core.network.services.createInterBankService
 import org.mifospay.core.network.services.createInvoiceService
 import org.mifospay.core.network.services.createKYCLevel1Service
 import org.mifospay.core.network.services.createNotificationService
+import org.mifospay.core.network.services.createOfficeService
 import org.mifospay.core.network.services.createRegistrationService
 import org.mifospay.core.network.services.createRunReportService
 import org.mifospay.core.network.services.createSavedCardService
@@ -67,4 +68,5 @@ class KtorfitClient(
     internal val beneficiaryApi by lazy { ktorfit.createBeneficiaryService() }
 
     internal val interBankApi by lazy { ktorfit.createInterBankService() }
+    internal val officeApi by lazy { ktorfit.createOfficeService() }
 }

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/services/OfficeService.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/services/OfficeService.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+ */
+package org.mifospay.core.network.services
+
+import de.jensklingenberg.ktorfit.http.GET
+import kotlinx.coroutines.flow.Flow
+import org.mifospay.core.model.office.Office
+import org.mifospay.core.network.utils.ApiEndPoints
+
+interface OfficeService {
+    @GET(ApiEndPoints.OFFICES)
+    fun getOffices(): Flow<List<Office>>
+}

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/ApiEndPoints.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/ApiEndPoints.kt
@@ -27,4 +27,5 @@ object ApiEndPoints {
     const val RUN_REPORT = "runreports"
     const val USER = "users"
     const val STANDING_INSTRUCTION = "standinginstructions"
+    const val OFFICES = "offices"
 }

--- a/feature/accounts/src/commonMain/kotlin/org/mifospay/feature/accounts/beneficiary/AddEditBeneficiaryScreen.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifospay/feature/accounts/beneficiary/AddEditBeneficiaryScreen.kt
@@ -67,6 +67,7 @@ import org.mifospay.core.designsystem.component.MifosButton
 import org.mifospay.core.designsystem.component.MifosLoadingDialog
 import org.mifospay.core.designsystem.component.MifosScaffold
 import org.mifospay.core.designsystem.component.MifosTextField
+import org.mifospay.core.model.office.Office
 import org.mifospay.core.model.utils.Locale
 import org.mifospay.core.model.utils.filterLocales
 import org.mifospay.core.ui.MifosDivider
@@ -85,6 +86,7 @@ internal fun AddEditBeneficiaryScreen(
 
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val localeList by viewModel.filteredLocalList.collectAsStateWithLifecycle()
+    val officeList by viewModel.officeList.collectAsStateWithLifecycle()
 
     EventsEffect(viewModel) { event ->
         when (event) {
@@ -110,6 +112,7 @@ internal fun AddEditBeneficiaryScreen(
     AddEditBeneficiaryScreenContent(
         state = state,
         localeList = localeList,
+        officeList = officeList,
         snackbarHostState = snackbarHostState,
         modifier = modifier,
         onAction = remember(viewModel) {
@@ -126,6 +129,7 @@ internal fun AddEditBeneficiaryScreenContent(
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
     onAction: (AEBAction) -> Unit,
+    officeList: List<Office>,
 ) {
     MifosScaffold(
         topBarTitle = stringResource(state.title),
@@ -185,86 +189,46 @@ internal fun AddEditBeneficiaryScreenContent(
                         localeList.filterLocales(state.locale)
                     }
                 }
-
-                var textFieldSize by remember { mutableStateOf(Size.Zero) }
-                var localeToggled by remember { mutableStateOf(false) }
-
-                ExposedDropdownMenuBox(
-                    expanded = localeToggled && localeList.isNotEmpty(),
-                    onExpandedChange = {
-                        localeToggled = !localeToggled
+                MifosDropdownMenu(
+                    label = stringResource(Res.string.feature_accounts_beneficiary_locale),
+                    selectedValue = state.locale,
+                    items = filteredLocalList,
+                    onItemSelected = { locale ->
+                        onAction(AEBAction.ChangeLocale(locale.localName))
                     },
-                ) {
-                    MifosTextField(
-                        label = stringResource(Res.string.feature_accounts_beneficiary_locale),
-                        value = state.locale,
-                        onValueChange = {
-                            localeToggled = true
-                            onAction(AEBAction.ChangeLocale(it))
-                        },
-                        onClickClearIcon = {
-                            onAction(AEBAction.ChangeLocale(""))
-                        },
-                        trailingIcon = {
-                            ExposedDropdownMenuDefaults.TrailingIcon(
-                                expanded = localeToggled,
-                            )
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .onGloballyPositioned { coordinates ->
-                                textFieldSize = coordinates.size.toSize()
-                            }
-                            .menuAnchor(MenuAnchorType.PrimaryNotEditable),
-                    )
-
-                    DropdownMenu(
-                        expanded = localeToggled,
-                        onDismissRequest = {
-                            localeToggled = false
-                        },
-                        properties = PopupProperties(
-                            focusable = false,
-                            dismissOnBackPress = true,
-                            dismissOnClickOutside = true,
-                            clippingEnabled = true,
-                        ),
-                        modifier = Modifier
-                            .width(with(LocalDensity.current) { textFieldSize.width.toDp() })
-                            .heightIn(max = 200.dp),
-                    ) {
-                        filteredLocalList.forEachIndexed { index, locale ->
-                            DropdownMenuItem(
-                                modifier = Modifier
-                                    .fillMaxWidth(),
-                                onClick = {
-                                    onAction(AEBAction.ChangeLocale(locale.localName))
-                                    localeToggled = false
-                                },
-                                text = {
-                                    Text(
-                                        text = locale.countryName,
-                                    )
-                                },
-                            )
-
-                            if (index != filteredLocalList.size - 1) {
-                                MifosDivider()
-                            }
-                        }
-                    }
-                }
+                    onValueChange = { value ->
+                        onAction(AEBAction.ChangeLocale(value))
+                    },
+                    onClearClick = {
+                        onAction(AEBAction.ChangeLocale(""))
+                    },
+                    itemToString = { locale -> locale.countryName },
+                )
             }
 
             item {
-                MifosTextField(
+                val filteredOfficeList by remember(officeList, state.officeName) {
+                    derivedStateOf {
+                        officeList.filter { office ->
+                            office.name.contains(state.officeName, ignoreCase = true)
+                        }
+                    }
+                }
+
+                MifosDropdownMenu(
                     label = stringResource(Res.string.feature_accounts_beneficiary_office_name),
-                    value = state.officeName,
-                    showClearIcon = false,
-                    readOnly = true,
-                    onValueChange = {
-                        onAction(AEBAction.ChangeOfficeName(it))
+                    selectedValue = state.officeName,
+                    items = filteredOfficeList,
+                    onItemSelected = { office ->
+                        onAction(AEBAction.ChangeOfficeName(office.name))
                     },
+                    onValueChange = { value ->
+                        onAction(AEBAction.ChangeOfficeName(value))
+                    },
+                    onClearClick = {
+                        onAction(AEBAction.ChangeOfficeName(""))
+                    },
+                    itemToString = { office -> office.name },
                 )
             }
 
@@ -305,6 +269,88 @@ internal fun AddEditBeneficiaryScreenContent(
                         modifier = Modifier
                             .clickable { onAction(AEBAction.OnQrScanClicked) },
                     )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun <T> MifosDropdownMenu(
+    label: String,
+    selectedValue: String,
+    items: List<T>,
+    onItemSelected: (T) -> Unit,
+    onValueChange: (String) -> Unit,
+    onClearClick: () -> Unit,
+    itemToString: (T) -> String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    var textFieldSize by remember { mutableStateOf(Size.Zero) }
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded && items.isNotEmpty(),
+        onExpandedChange = {
+            if (enabled) {
+                expanded = !expanded
+            }
+        },
+        modifier = modifier,
+    ) {
+        MifosTextField(
+            label = label,
+            value = selectedValue,
+            onValueChange = {
+                expanded = true
+                onValueChange(it)
+            },
+            onClickClearIcon = onClearClick,
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(
+                    expanded = expanded,
+                )
+            },
+            enabled = enabled,
+            modifier = Modifier
+                .fillMaxWidth()
+                .onGloballyPositioned { coordinates ->
+                    textFieldSize = coordinates.size.toSize()
+                }
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+        )
+
+        DropdownMenu(
+            expanded = expanded && items.isNotEmpty(),
+            onDismissRequest = {
+                expanded = false
+            },
+            properties = PopupProperties(
+                focusable = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true,
+                clippingEnabled = true,
+            ),
+            modifier = Modifier
+                .width(with(LocalDensity.current) { textFieldSize.width.toDp() })
+                .heightIn(max = 200.dp),
+        ) {
+            items.forEachIndexed { index, item ->
+                DropdownMenuItem(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        onItemSelected(item)
+                        expanded = false
+                    },
+                    text = {
+                        Text(text = itemToString(item))
+                    },
+                )
+
+                if (index != items.size - 1) {
+                    MifosDivider()
                 }
             }
         }

--- a/feature/accounts/src/commonMain/kotlin/org/mifospay/feature/accounts/beneficiary/AddEditBeneficiaryViewModel.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifospay/feature/accounts/beneficiary/AddEditBeneficiaryViewModel.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -38,17 +39,21 @@ import org.mifospay.core.common.DataState
 import org.mifospay.core.common.getSerialized
 import org.mifospay.core.common.setSerialized
 import org.mifospay.core.data.repository.LocalAssetRepository
+import org.mifospay.core.data.repository.OfficeRepository
 import org.mifospay.core.data.repository.SelfServiceRepository
 import org.mifospay.core.model.beneficiary.Beneficiary
 import org.mifospay.core.model.beneficiary.BeneficiaryPayload
 import org.mifospay.core.model.beneficiary.BeneficiaryUpdatePayload
+import org.mifospay.core.model.office.Office
 import org.mifospay.core.ui.utils.BaseViewModel
 import org.mifospay.feature.accounts.beneficiary.AEBAction.Internal.HandleBeneficiaryAddEditResult
+import org.mifospay.feature.accounts.beneficiary.AEBState.Companion.DEFAULT_OFFICE
 import org.mifospay.feature.accounts.beneficiary.AEBState.DialogState.Error
 
 internal class AddEditBeneficiaryViewModel(
     private val localAssetRepository: LocalAssetRepository,
     private val repository: SelfServiceRepository,
+    private val officeRepository: OfficeRepository,
     private val json: Json,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<AEBState, AEBEvent, AEBAction>(
@@ -91,6 +96,19 @@ internal class AddEditBeneficiaryViewModel(
         initialValue = emptyList(),
         started = SharingStarted.WhileSubscribed(5_000),
     )
+
+    val officeList = officeRepository.getOffices()
+        .mapLatest { dataState ->
+            when (dataState) {
+                is DataState.Success -> dataState.data.ifEmpty { listOf(DEFAULT_OFFICE) }
+                else -> listOf(DEFAULT_OFFICE)
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = listOf(DEFAULT_OFFICE),
+        )
 
     init {
         stateFlow
@@ -267,7 +285,7 @@ internal data class AEBState(
     val accountNumber: String,
     val transferLimit: Int,
     val locale: String = "en_US",
-    val officeName: String = OFFICE_NAME,
+    val officeName: String = DEFAULT_OFFICE.name,
     val accountType: Int = SAVINGS_ACC_ID,
     val beneficiaryId: Long? = null,
     @Transient
@@ -307,7 +325,7 @@ internal data class AEBState(
 
     companion object {
         const val SAVINGS_ACC_ID = 2
-        const val OFFICE_NAME = "Head Office"
+        val DEFAULT_OFFICE = Office(id = 1, name = "Head Office", nameDecorated = "Head Office")
     }
 }
 


### PR DESCRIPTION
## Add Office API Integration in AddBeneficiaryScreen

### Summary
Implemented office endpoint integration to fetch the list of offices dynamically, replacing the hardcoded "Head  Office" value in the beneficiary creation flow.

### Behavior Changes
| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/a193d009-207c-4dde-a614-30c8162091e8" controls height="120"></video> | <video src="https://github.com/user-attachments/assets/9327a052-03f9-4c54-91fd-0283f362ffdd" controls height="120"></video> |

### Changes Made
- Created `OfficeService` interface for `/api/v1/offices` endpoint
- Implemented `OfficeRepository` with automatic retry logic (3 attempts with exponential backoff: 1s, 2s, 4s)
- Integrated `OfficeRepository` in `AddEditBeneficiaryViewModel`
- Updated UI to display dynamic office dropdown with fallback to "Head Office" on failure
- Created reusable `MifosDropdownMenu` component for locale and office selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Office selection added to beneficiary add/edit screen with live office list, loading/error states and a default "Head Office".
  * App now fetches office data from backend and exposes office entries for selection.

* **Refactor**
  * Replaced inline locale and office dropdowns with a reusable dropdown component for consistent behavior and simpler UI integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->