### PR TITLE
chore: update .gitignore for cmp-ios auto-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,20 @@ build/
 build-cache/
 .externalNativeBuild
 .cxx
+# iOS/CocoaPods (cmp-ios module)
+cmp-ios/Podfile.lock
+cmp-ios/Pods/
+cmp-ios/iosApp.xcworkspace/xcuserdata/
+cmp-ios/iosApp.xcodeproj/xcuserdata/
+!cmp-ios/iosApp.xcodeproj/project.pbxproj
+
+# Legacy iosApp paths (kept for backwards compatibility)
 iosApp/Podfile.lock
 iosApp/Pods/*
 iosApp/iosApp.xcworkspace/*
 iosApp/iosApp.xcodeproj/*
 !iosApp/iosApp.xcodeproj/project.pbxproj
+
 cmp-shared/cmp-shared.podspec
 
 # Eclipse project files
@@ -76,5 +85,8 @@ secrets/
 
 # Sync Log File
 *.log
+
+# Java heap dumps
+*.hprof
 
 *.provisionprofile


### PR DESCRIPTION
## Summary
Add ignore patterns for auto-generated files:
- `cmp-ios/Pods/` (CocoaPods dependencies)
- `cmp-ios/iosApp.xcodeproj/xcuserdata/` (Xcode user settings)
- `cmp-ios/iosApp.xcworkspace/xcuserdata/` (workspace user settings)
- `*.hprof` (Java heap dump files)

## Context
These files were showing up as untracked because the existing `.gitignore` had patterns for the old `iosApp/` path instead of the current `cmp-ios/` path.

## Test plan
- [x] Verify auto-generated files no longer appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded ignore rules to cover iOS/CocoaPods build artifacts, workspace metadata, and Java heap dumps, reducing incidental files in version control.
  * Preserved existing ignore behavior for logs and provisioning profiles.
  * Streamlines contributor workflow with cleaner diffs and less repository noise.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->