### PR TITLE
fix(fastlane): sync ios_config.rb with kmp-project-template

### DIFF
--- a/fastlane-config/ios_config.rb
+++ b/fastlane-config/ios_config.rb
@@ -1,38 +1,50 @@
+require_relative 'project_config'
+
 module FastlaneConfig
   module IosConfig
+    # Firebase Configuration (reads from IOS)
     FIREBASE_CONFIG = {
-      firebase_app_id: "1:728434912738:ios:86a7badfaed88b841a1dbb",
-      firebase_service_creds_file: "secrets/firebaseAppDistributionServiceCredentialsFile.json",
-      firebase_groups: "mifos-mobile-apps"
+      firebase_app_id: ProjectConfig::IOS[:firebase][:app_id],
+      firebase_service_creds_file: ProjectConfig.firebase_credentials_file,
+      firebase_groups: ProjectConfig::IOS[:firebase][:groups]
     }
 
+    # Build Configuration (reads from both IOS and IOS_SHARED)
     BUILD_CONFIG = {
-      project_path: "cmp-ios/iosApp.xcodeproj",
-      workspace_path: "cmp-ios/iosApp.xcworkspace",
-      configuration: "Release",
-      podfile_path: "cmp-ios/Podfile",
-      plist_path: "cmp-ios/iosApp/Info.plist",
-      scheme: "cmp-ios",
-      output_name: "iosApp.ipa",
-      output_directory: "cmp-ios/build",
-      match_git_private_key: "./secrets/match_ci_key",
-      target: "iosApp",
-      team_id: "L432S2FZP5",
-      code_sign_identity: "Apple Distribution",
-      configuration: "Release",
-      match_type: "adhoc",
-      app_identifier: "org.mifospay",
-      provisioning_profile_name: "match AdHoc org.mifospay",
-      git_url: "git@github.com:openMF/ios-provisioning-profile.git",
-      git_branch: "mifospay",
-      key_id: "7V3ABCDEFG",
-      issuer_id: "7ab9e231-9603-4c3e-a147-be3b0f123456",
-      key_filepath: "./secrets/Auth_key.p8",
-      version_number: "1.1.0",
-      metadata_path: "./fastlane/metadata/ios",
-      app_rating_config_path: "./fastlane/age_rating.json",
-      screenshots_ios_path: "./fastlane/screenshots_ios",
-      screenshots_macos_path: "./fastlane/screenshots_macos",
+      # App-specific (from IOS)
+      app_identifier: ProjectConfig::IOS[:app_identifier],
+      project_path: ProjectConfig::IOS[:project_path],
+      workspace_path: ProjectConfig::IOS[:workspace_path],
+      plist_path: ProjectConfig::IOS[:plist_path],
+      scheme: ProjectConfig::IOS[:scheme],
+      output_name: ProjectConfig::IOS[:output_name],
+      output_directory: ProjectConfig::IOS[:output_directory],
+      version_number: ProjectConfig::IOS[:version_number],
+      metadata_path: ProjectConfig::IOS[:metadata_path],
+      app_rating_config_path: ProjectConfig::IOS[:age_rating_config_path],
+
+      # Shared (from IOS_SHARED)
+      team_id: ProjectConfig::IOS_SHARED[:team_id],
+      ci_provider: ProjectConfig::IOS_SHARED[:ci_provider],
+
+      # App Store Connect API (from IOS_SHARED)
+      key_id: ProjectConfig::IOS_SHARED[:app_store_connect][:key_id],
+      issuer_id: ProjectConfig::IOS_SHARED[:app_store_connect][:issuer_id],
+      key_filepath: ProjectConfig::IOS_SHARED[:app_store_connect][:key_filepath],
+
+      # Code Signing & Match (from IOS_SHARED)
+      match_type: ProjectConfig::IOS_SHARED[:code_signing][:match_type],
+      match_git_private_key: ProjectConfig::IOS_SHARED[:code_signing][:match_git_private_key],
+      git_url: ProjectConfig::IOS_SHARED[:code_signing][:match_git_url],
+      git_branch: ProjectConfig::IOS_SHARED[:code_signing][:match_git_branch],
+      provisioning_profile_name: ProjectConfig::IOS_SHARED[:code_signing][:provisioning_profiles][:adhoc],
+      provisioning_profile_appstore: ProjectConfig::IOS_SHARED[:code_signing][:provisioning_profiles][:appstore]
     }
+
+    # TestFlight Configuration (from IOS_SHARED)
+    TESTFLIGHT_CONFIG = ProjectConfig::IOS_SHARED[:testflight]
+
+    # App Store Configuration (from IOS_SHARED)
+    APPSTORE_CONFIG = ProjectConfig::IOS_SHARED[:appstore]
   end
 end


### PR DESCRIPTION
## Summary
- Add `require_relative 'project_config'` for proper module loading
- Remove duplicate `:configuration` key (was on lines 12 and 22)
- Add `TESTFLIGHT_CONFIG` from `ProjectConfig::IOS_SHARED[:testflight]`
- Add `APPSTORE_CONFIG` from `ProjectConfig::IOS_SHARED[:appstore]`
- Update `BUILD_CONFIG` to reference `ProjectConfig` instead of hardcoded values

## Problem
CI was failing for `ios beta` and `ios release` lanes with errors:
```
Error in your Fastfile at line 555
testflight_config = FastlaneConfig::IosConfig::TESTFLIGHT_CONFIG

Error in your Fastfile at line 658
appstore_config = FastlaneConfig::IosConfig::APPSTORE_CONFIG
```

Also had warning: `key :configuration is duplicated and overwritten on line 22`

## Test plan
- [ ] CI passes for ios beta lane
- [ ] CI passes for ios release lane
- [ ] No duplicate key warnings in fastlane output

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS build infrastructure by centralizing configuration management. Build and deployment settings are now sourced from a unified configuration system rather than hard-coded values, enhancing maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->