### PR TITLE
fix(home): show server error messages instead of generic static text

### DIFF
--- a/core/data/src/commonMain/kotlin/org/mifospay/core/data/repositoryImpl/SelfServiceRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/mifospay/core/data/repositoryImpl/SelfServiceRepositoryImpl.kt
@@ -109,7 +109,7 @@ class SelfServiceRepositoryImpl(
         return apiManager.clientsApi
             .getAccounts(clientId, Constants.SAVINGS)
             .map { it.toAccount() }
-            .asDataStateFlow().flowOn(dispatcher)
+            .asDataStateFlow(parseMifosError).flowOn(dispatcher)
     }
 
     override fun getAccountAndBeneficiaryList(clientId: Long): Flow<DataState<AccountContent>> {
@@ -154,7 +154,7 @@ class SelfServiceRepositoryImpl(
 
         return accounts.combine(transactions) { accountList, transaction ->
             AccountsWithTransactions(accountList, transaction)
-        }.asDataStateFlow()
+        }.asDataStateFlow(parseMifosError)
     }
 
     override fun getActiveAccountsWithTransactionsPerAccount(
@@ -176,7 +176,7 @@ class SelfServiceRepositoryImpl(
             combine(flows) { pairs ->
                 pairs.toMap()
             }
-        }.asDataStateFlow()
+        }.asDataStateFlow(parseMifosError)
     }
 
     override fun getActiveAccounts(
@@ -220,7 +220,7 @@ class SelfServiceRepositoryImpl(
                         )
                     }
                 }
-        }.asDataStateFlow()
+        }.asDataStateFlow(parseMifosError)
     }
 
     override fun getTransactions(accountId: List<Long>, limit: Int?): Flow<List<Transaction>> {
@@ -246,7 +246,7 @@ class SelfServiceRepositoryImpl(
                 }
             }
             .flowOn(dispatcher)
-            .asDataStateFlow()
+            .asDataStateFlow(parseMifosError)
     }
 
     override fun getAccountsTransactions(
@@ -265,11 +265,11 @@ class SelfServiceRepositoryImpl(
                         .filter { transactions -> transactions.isNotEmpty() }
                 }
             }
-            .asDataStateFlow()
+            .asDataStateFlow(parseMifosError)
     }
 
     override fun getBeneficiaryList(): Flow<DataState<List<Beneficiary>>> {
-        return apiManager.beneficiaryApi.beneficiaryList().asDataStateFlow().flowOn(dispatcher)
+        return apiManager.beneficiaryApi.beneficiaryList().asDataStateFlow(parseMifosError).flowOn(dispatcher)
     }
 
     override suspend fun createBeneficiary(

--- a/core/data/src/commonMain/kotlin/org/mifospay/core/data/repositoryImpl/SelfServiceRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/mifospay/core/data/repositoryImpl/SelfServiceRepositoryImpl.kt
@@ -35,6 +35,7 @@ import org.mifospay.core.data.mapper.toModelAccountType
 import org.mifospay.core.data.mapper.toTransactionList
 import org.mifospay.core.data.repository.SelfServiceRepository
 import org.mifospay.core.data.util.Constants
+import org.mifospay.core.data.util.parseMifosError
 import org.mifospay.core.model.account.Account
 import org.mifospay.core.model.account.AccountContent
 import org.mifospay.core.model.account.AccountsWithTransactions
@@ -186,7 +187,7 @@ class SelfServiceRepositoryImpl(
             .map { entity -> entity.savingsAccounts.filter { it.status.active } }
             .map { it.toAccount() }
             .flowOn(dispatcher)
-            .asDataStateFlow()
+            .asDataStateFlow(parseMifosError)
     }
 
     override fun getActiveAccountsWithAccountTransferTemplate(

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/model/entity/client/ClientAccountsEntity.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/model/entity/client/ClientAccountsEntity.kt
@@ -16,7 +16,7 @@ import org.mifospay.core.model.savingsaccount.SavingAccountEntity
 data class ClientAccountsEntity(
     var savingsAccounts: List<SavingAccountEntity> = emptyList(),
     val groupLoanIndividualMonitoringAccounts: List<String?> = emptyList(),
-    val guarantorAccounts: List<Long> = emptyList(),
+    val guarantorAccounts: List<GuarantorAccountEntity> = emptyList(),
 ) {
 
     fun withSavingsAccounts(savingsAccounts: List<SavingAccountEntity>): ClientAccountsEntity {

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/model/entity/client/GuarantorAccountEntity.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/model/entity/client/GuarantorAccountEntity.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+ */
+package org.mifospay.core.network.model.entity.client
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GuarantorAccountEntity(
+    val id: Long? = null,
+    val accountNo: String? = null,
+    val productId: Long? = null,
+    val productName: String? = null,
+    val shortProductName: String? = null,
+    val status: LoanStatusEntity? = null,
+    val loanType: Status? = null,
+    val loanCycle: Int? = null,
+    val inArrears: Boolean? = null,
+    val originalLoan: Double? = null,
+    val loanBalance: Double? = null,
+    val isActive: Boolean? = null,
+    val relationship: String? = null,
+)
+
+@Serializable
+data class LoanStatusEntity(
+    val id: Int? = null,
+    val code: String? = null,
+    val value: String? = null,
+    val pendingApproval: Boolean? = null,
+    val waitingForDisbursal: Boolean? = null,
+    val active: Boolean? = null,
+    val closedObligationsMet: Boolean? = null,
+    val closedWrittenOff: Boolean? = null,
+    val closedRescheduled: Boolean? = null,
+    val closed: Boolean? = null,
+    val overpaid: Boolean? = null,
+)

--- a/feature/home/src/commonMain/composeResources/values/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="feature_home_account_success">Account marked as default</string>
     <string name="feature_home_account_error">Error marking account as default</string>
     <string name="feature_home_no_account">"No accounts found"</string>
+    <string name="feature_home_failed_to_load_accounts">Failed to load accounts. Please try again.</string>
     <string name="feature_home_account_number">A/c No: %1$s</string>
 
 </resources>

--- a/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeScreen.kt
@@ -247,6 +247,7 @@ fun HomeScreenContent(
 
                 is ViewState.Error -> {
                     ErrorScreenContent(
+                        subTitle = viewState.message,
                         onClickRetry = {
                             onAction(HomeAction.OnRetryClicked)
                         },

--- a/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeViewModel.kt
@@ -16,7 +16,9 @@ import kotlinx.serialization.Serializable
 import mobile_wallet.feature.home.generated.resources.Res
 import mobile_wallet.feature.home.generated.resources.feature_home_account_error
 import mobile_wallet.feature.home.generated.resources.feature_home_account_success
+import mobile_wallet.feature.home.generated.resources.feature_home_failed_to_load_accounts
 import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.getString
 import org.mifospay.core.common.DataState
 import org.mifospay.core.data.repository.SelfServiceRepository
 import org.mifospay.core.datastore.UserPreferencesRepository
@@ -51,12 +53,13 @@ class HomeViewModel(
                 .collect { result ->
                     when (result) {
                         is DataState.Error -> {
+                            val errorMessage = result.exception.message
+                                ?.takeIf { it != "null" && it.isNotBlank() }
+                                ?: getString(Res.string.feature_home_failed_to_load_accounts)
                             mutableStateFlow.update {
                                 it.copy(
                                     isRefreshing = false,
-                                    viewState = ViewState.Error(
-                                        result.message ?: "Failed to load accounts",
-                                    ),
+                                    viewState = ViewState.Error(errorMessage),
                                 )
                             }
                         }

--- a/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeViewModel.kt
@@ -16,7 +16,6 @@ import kotlinx.serialization.Serializable
 import mobile_wallet.feature.home.generated.resources.Res
 import mobile_wallet.feature.home.generated.resources.feature_home_account_error
 import mobile_wallet.feature.home.generated.resources.feature_home_account_success
-import mobile_wallet.feature.home.generated.resources.feature_home_no_account
 import org.jetbrains.compose.resources.StringResource
 import org.mifospay.core.common.DataState
 import org.mifospay.core.data.repository.SelfServiceRepository
@@ -55,7 +54,9 @@ class HomeViewModel(
                             mutableStateFlow.update {
                                 it.copy(
                                     isRefreshing = false,
-                                    viewState = ViewState.Error(Res.string.feature_home_no_account),
+                                    viewState = ViewState.Error(
+                                        result.message ?: "Failed to load accounts",
+                                    ),
                                 )
                             }
                         }
@@ -364,7 +365,7 @@ data class HomeState(
 sealed interface ViewState {
     data object Loading : ViewState
 
-    data class Error(val message: StringResource) : ViewState
+    data class Error(val message: String) : ViewState
 
     data object Content : ViewState
 


### PR DESCRIPTION
## Summary
- Display actual server error messages on Home screen instead of generic "No accounts found" text
- Parse Mifos error responses properly using existing `parseMifosError` utility
- Improve user experience by showing meaningful error information

## Changes
- Changed `ViewState.Error` to hold dynamic `String` instead of `StringResource`
- Extract error message from `DataState.Error` in `getAccounts()`
- Pass server error message to `ErrorScreenContent` subtitle
- Added `parseMifosError` to `getActiveAccounts()` in `SelfServiceRepositoryImpl`

## Problem
When the server returned errors like:
```json
{
  "defaultUserMessage": "Insufficient privileges to perform this action.",
  "httpStatusCode": "403",
  "errors": [{"defaultUserMessage": "User has no authority to READ clients"}]
}
```
The app was showing a generic "No accounts found" message instead of the actual server error.

## Test plan
- [ ] Trigger a 403 error (user without READ clients permission)
- [ ] Verify Home screen shows the actual server error message
- [ ] Verify retry button works
- [ ] Test other error scenarios (401, 500, network errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Home error screen now shows a subtitle with the specific error message for clearer feedback.
  * Account-loading failures surface more informative, dynamic messages instead of a generic notice.
  * Added a default user-facing message: "Failed to load accounts. Please try again."

* **New Features**
  * Account data now includes richer guarantor details for more complete account information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->