### PR TITLE
feat(mpay-qr): add multi-wallet account selection for QR generation

### DIFF
--- a/feature/mpay-qr/src/commonMain/composeResources/values/strings.xml
+++ b/feature/mpay-qr/src/commonMain/composeResources/values/strings.xml
@@ -57,4 +57,14 @@
     <string name="feature_mpay_qr_scan_instruction">Scan with any payment app</string>
     <string name="feature_mpay_qr_downloaded">QR code downloaded</string>
 
+    <!-- Inter-Bank QR Placeholder -->
+    <string name="feature_mpay_qr_inter_bank_unavailable">Inter-Bank QR Not Available</string>
+    <string name="feature_mpay_qr_external_id_required">Your account doesn\'t have an external ID configured. Contact your bank to enable inter-bank transfers.</string>
+
+    <!-- Account Picker -->
+    <string name="feature_mpay_qr_select_account">Select Account</string>
+    <string name="feature_mpay_qr_has_external_id">Inter-bank enabled</string>
+    <string name="feature_mpay_qr_no_external_id">Inter-bank not available</string>
+    <string name="feature_mpay_qr_account_selected">Account selected</string>
+
 </resources>

--- a/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/MpayQrScreen.kt
+++ b/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/MpayQrScreen.kt
@@ -50,6 +50,7 @@ import io.github.alexzhirkevich.qrose.toByteArray
 import mobile_wallet.feature.mpay_qr.generated.resources.Res
 import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_copied
 import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_downloaded
+import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_external_id_required
 import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_go_back
 import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_receive_money
 import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_scan_to_pay
@@ -68,7 +69,9 @@ import org.mifospay.core.model.client.Client
 import org.mifospay.core.ui.MifosProgressIndicator
 import org.mifospay.core.ui.utils.EventsEffect
 import org.mifospay.feature.mpay.qr.components.AccountIdSection
+import org.mifospay.feature.mpay.qr.components.AccountPickerBottomSheet
 import org.mifospay.feature.mpay.qr.components.AccountSelectorCard
+import org.mifospay.feature.mpay.qr.components.InterBankPlaceholder
 import org.mifospay.feature.mpay.qr.components.QrActionButtons
 import org.mifospay.feature.mpay.qr.components.QrCodeCard
 import org.mifospay.feature.mpay.qr.components.QrType
@@ -217,6 +220,20 @@ private fun MpayQrScreenContent(
         }
     }
 
+    // Account Picker Bottom Sheet
+    if (state.isAccountPickerVisible) {
+        AccountPickerBottomSheet(
+            accounts = state.accounts,
+            selectedAccount = state.selectedAccount,
+            onAccountSelected = { account ->
+                onAction(MpayQrAction.SelectAccount(account))
+            },
+            onDismiss = {
+                onAction(MpayQrAction.DismissAccountPicker)
+            },
+        )
+    }
+
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         state = lazyListState,
@@ -239,8 +256,18 @@ private fun MpayQrScreenContent(
         item {
             AccountSelectorCard(
                 client = state.client,
-                account = state.defaultAccount,
-                isPrimary = true,
+                account = state.selectedAccount?.let { account ->
+                    DefaultAccount(
+                        accountId = account.id,
+                        accountNo = account.number,
+                    )
+                } ?: state.defaultAccount,
+                isPrimary = state.selectedAccount?.id == state.defaultAccount.accountId ||
+                    state.selectedAccount == null,
+                hasMultipleAccounts = state.accounts.size > 1,
+                onClick = {
+                    onAction(MpayQrAction.ShowAccountPicker)
+                },
             )
         }
 
@@ -255,15 +282,34 @@ private fun MpayQrScreenContent(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    val data = if (page == 0) contentState.intraBankData else contentState.interBankData
-                    val qrType = if (page == 0) QrType.INTRA_BANK else QrType.INTER_BANK
-
-                    QrCodeCard(
-                        data = data,
-                        options = contentState.options,
-                        qrType = qrType,
-                        modifier = Modifier.padding(horizontal = KptTheme.spacing.sm),
-                    )
+                    when (page) {
+                        0 -> {
+                            // Intra-Bank - always show QR
+                            QrCodeCard(
+                                data = contentState.intraBankData,
+                                options = contentState.options,
+                                qrType = QrType.INTRA_BANK,
+                                modifier = Modifier.padding(horizontal = KptTheme.spacing.sm),
+                            )
+                        }
+                        1 -> {
+                            // Inter-Bank - show QR or placeholder
+                            if (contentState.interBankData != null) {
+                                QrCodeCard(
+                                    data = contentState.interBankData,
+                                    options = contentState.options,
+                                    qrType = QrType.INTER_BANK,
+                                    modifier = Modifier.padding(horizontal = KptTheme.spacing.sm),
+                                )
+                            } else {
+                                InterBankPlaceholder(
+                                    reason = contentState.interBankUnavailableReason
+                                        ?: stringResource(Res.string.feature_mpay_qr_external_id_required),
+                                    modifier = Modifier.padding(horizontal = KptTheme.spacing.sm),
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -291,38 +337,46 @@ private fun MpayQrScreenContent(
 
         // Share and Download buttons
         item {
-            val currentData = if (pagerState.currentPage == 0) {
-                contentState.intraBankData
-            } else {
-                contentState.interBankData
+            val currentData = when {
+                pagerState.currentPage == 0 -> contentState.intraBankData
+                contentState.interBankData != null -> contentState.interBankData
+                else -> null
             }
-            val qrPainter = rememberQrCodePainter(
-                data = currentData,
-                options = contentState.options,
-            )
 
-            QrActionButtons(
-                onShareClick = {
-                    val bytes = qrPainter.toByteArray(1024, 1024, ImageFormat.PNG)
-                    onAction(MpayQrAction.ShareQrCode(bytes))
-                },
-                onDownloadClick = {
-                    val bytes = qrPainter.toByteArray(1024, 1024, ImageFormat.PNG)
-                    onAction(MpayQrAction.DownloadQrCode(bytes))
-                },
-            )
+            if (currentData != null) {
+                val qrPainter = rememberQrCodePainter(
+                    data = currentData,
+                    options = contentState.options,
+                )
+
+                QrActionButtons(
+                    onShareClick = {
+                        val bytes = qrPainter.toByteArray(1024, 1024, ImageFormat.PNG)
+                        onAction(MpayQrAction.ShareQrCode(bytes))
+                    },
+                    onDownloadClick = {
+                        val bytes = qrPainter.toByteArray(1024, 1024, ImageFormat.PNG)
+                        onAction(MpayQrAction.DownloadQrCode(bytes))
+                    },
+                )
+            }
         }
 
         // Account IDs section
         item {
+            val accountNo = state.selectedAccount?.number ?: state.defaultAccount.accountNo
+            val externalId = state.selectedAccount?.externalId ?: state.accountExternalId
+
             AccountIdSection(
-                accountNumber = state.defaultAccount.accountNo,
-                externalId = state.accountExternalId.ifBlank { null },
+                accountNumber = accountNo,
+                externalId = externalId.ifBlank { null },
                 onCopyAccountNumber = {
-                    onAction(MpayQrAction.CopyToClipboard(state.defaultAccount.accountNo))
+                    onAction(MpayQrAction.CopyToClipboard(accountNo))
                 },
                 onCopyExternalId = {
-                    onAction(MpayQrAction.CopyToClipboard(state.accountExternalId))
+                    if (externalId.isNotBlank()) {
+                        onAction(MpayQrAction.CopyToClipboard(externalId))
+                    }
                 },
             )
         }

--- a/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/MpayQrViewModel.kt
+++ b/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/MpayQrViewModel.kt
@@ -40,11 +40,14 @@ import kotlinx.serialization.Transient
 import mobile_wallet.feature.mpay_qr.generated.resources.Res
 import mobile_wallet.feature.mpay_qr.generated.resources.logo
 import org.jetbrains.compose.resources.painterResource
+import org.mifospay.core.common.DataState
 import org.mifospay.core.common.getSerialized
 import org.mifospay.core.common.setSerialized
+import org.mifospay.core.data.repository.AccountRepository
 import org.mifospay.core.data.repository.LocalAssetRepository
 import org.mifospay.core.data.util.MpayQrCodeProcessor
 import org.mifospay.core.datastore.UserPreferencesRepository
+import org.mifospay.core.model.account.Account
 import org.mifospay.core.model.account.DefaultAccount
 import org.mifospay.core.model.client.Client
 import org.mifospay.core.model.utils.QrCodeData
@@ -58,6 +61,7 @@ import template.core.base.designsystem.theme.KptTheme
 class MpayQrViewModel(
     localRepository: LocalAssetRepository,
     repository: UserPreferencesRepository,
+    private val accountRepository: AccountRepository,
     savedStateHandle: SavedStateHandle,
     private val ioDispatcher: CoroutineDispatcher,
 ) : BaseViewModel<MpayQrState, MpayQrEvent, MpayQrAction>(
@@ -117,8 +121,40 @@ class MpayQrViewModel(
             savedStateHandle.setSerialized(key = KEY_STATE, value = it)
         }.launchIn(viewModelScope)
 
+        loadAccounts()
+    }
+
+    private fun loadAccounts() {
         viewModelScope.launch {
-            sendAction(MpayQrAction.Internal.GenerateQr)
+            accountRepository.getSelfAccounts(state.client.id)
+                .collect { result ->
+                    when (result) {
+                        is DataState.Success -> {
+                            val accounts = result.data
+                            val defaultAcc = accounts.find { it.id == state.defaultAccount.accountId }
+                                ?: accounts.firstOrNull()
+
+                            mutableStateFlow.update {
+                                it.copy(
+                                    accounts = accounts,
+                                    selectedAccount = defaultAcc,
+                                    accountExternalId = defaultAcc?.externalId ?: "",
+                                )
+                            }
+                            sendAction(MpayQrAction.Internal.GenerateQr)
+                        }
+
+                        is DataState.Error -> {
+                            Logger.e { "Failed to load accounts: ${result.exception.message}" }
+                            // Still generate QR with default account
+                            sendAction(MpayQrAction.Internal.GenerateQr)
+                        }
+
+                        is DataState.Loading -> {
+                            // Loading state handled by viewState
+                        }
+                    }
+                }
         }
     }
 
@@ -195,6 +231,25 @@ class MpayQrViewModel(
                 sendEvent(MpayQrEvent.ShowSnackbar(action.text))
             }
 
+            is MpayQrAction.ShowAccountPicker -> {
+                mutableStateFlow.update { it.copy(isAccountPickerVisible = true) }
+            }
+
+            is MpayQrAction.DismissAccountPicker -> {
+                mutableStateFlow.update { it.copy(isAccountPickerVisible = false) }
+            }
+
+            is MpayQrAction.SelectAccount -> {
+                mutableStateFlow.update {
+                    it.copy(
+                        selectedAccount = action.account,
+                        accountExternalId = action.account.externalId ?: "",
+                        isAccountPickerVisible = false,
+                    )
+                }
+                generateQr() // Regenerate QR for new account
+            }
+
             is MpayQrAction.Internal.GenerateQr -> generateQr()
         }
     }
@@ -215,41 +270,49 @@ class MpayQrViewModel(
 
             Logger.d { "QR Generate - client.id: ${state.client.id}, defaultAccount.accountId: ${state.defaultAccount.accountId}, qrData.clientId: ${state.qrData.clientId}, qrData.accountId: ${state.qrData.accountId}" }
 
-            try {
-                val (intraBankData, interBankData) = withContext(ioDispatcher) {
-                    Pair(
-                        MpayQrCodeProcessor.encodeMpayString(state.qrData),
-                        MpayQrCodeProcessor.encodeMpayString(state.interBankQrData),
-                    )
-                }
+            // Generate Intra-Bank QR (always works with internal IDs)
+            val intraBankData = withContext(ioDispatcher) {
+                MpayQrCodeProcessor.encodeMpayString(state.qrData)
+            }
 
-                mutableStateFlow.update {
-                    it.copy(
-                        viewState = MpayQrState.ViewState.Content(
-                            intraBankData = intraBankData,
-                            interBankData = interBankData,
-                        ),
-                    )
+            // Try to generate Inter-Bank QR (requires external ID)
+            val (interBankData, interBankReason) = withContext(ioDispatcher) {
+                if (state.accountExternalId.isBlank()) {
+                    // No external ID - return null with reason
+                    null to "External ID not configured. Contact your bank to enable inter-bank transfers."
+                } else {
+                    try {
+                        MpayQrCodeProcessor.encodeMpayString(state.interBankQrData) to null
+                    } catch (e: IllegalArgumentException) {
+                        null to (e.message ?: "Failed to generate inter-bank QR code")
+                    }
                 }
-            } catch (e: IllegalArgumentException) {
-                mutableStateFlow.update {
-                    it.copy(
-                        viewState = MpayQrState.ViewState.Error(
-                            e.message ?: "Failed to generate QR code",
-                        ),
-                    )
-                }
+            }
+
+            mutableStateFlow.update {
+                it.copy(
+                    viewState = MpayQrState.ViewState.Content(
+                        intraBankData = intraBankData,
+                        interBankData = interBankData,
+                        interBankUnavailableReason = interBankReason,
+                    ),
+                )
             }
         }
     }
 
     private fun initiateSetAmount() {
         viewModelScope.launch {
-            val (intraBankData, interBankData) = withContext(ioDispatcher) {
-                Pair(
-                    MpayQrCodeProcessor.encodeMpayString(state.qrData),
-                    MpayQrCodeProcessor.encodeMpayString(state.interBankQrData),
-                )
+            val intraBankData = withContext(ioDispatcher) {
+                MpayQrCodeProcessor.encodeMpayString(state.qrData)
+            }
+
+            val interBankData = if (state.accountExternalId.isNotBlank()) {
+                withContext(ioDispatcher) {
+                    MpayQrCodeProcessor.encodeMpayString(state.interBankQrData)
+                }
+            } else {
+                null
             }
 
             updateContent {
@@ -291,14 +354,33 @@ data class MpayQrState(
     val defaultAccount: DefaultAccount,
 
     /**
+     * All accounts available for the user. Loaded from AccountRepository.
+     */
+    @Transient
+    val accounts: List<Account> = emptyList(),
+
+    /**
+     * Currently selected account for QR generation.
+     * Defaults to the default account on initial load.
+     */
+    @Transient
+    val selectedAccount: Account? = null,
+
+    /**
+     * Whether the account picker bottom sheet is visible.
+     */
+    @Transient
+    val isAccountPickerVisible: Boolean = false,
+
+    /**
      * The FSP ID (bank/tenant identifier) used for routing.
      * When scanning, if QR's fspId matches scanner's fspId → intra-bank transfer.
      */
     val fspId: String = "",
 
     /**
-     * The external ID of the default account, used for inter-bank QR codes.
-     * This is fetched from the saved account external IDs map in the datastore.
+     * The external ID of the selected account, used for inter-bank QR codes.
+     * Updated when a new account is selected.
      */
     val accountExternalId: String = "",
 
@@ -312,17 +394,23 @@ data class MpayQrState(
         fspId = fspId,
         clientId = client.id,
         clientName = client.displayName,
-        accountNo = defaultAccount.accountNo,
-        accountId = defaultAccount.accountId,
-        officeId = client.officeId,
+        accountNo = selectedAccount?.number ?: defaultAccount.accountNo,
+        accountId = selectedAccount?.id ?: defaultAccount.accountId,
+        officeId = selectedAccount?.officeId?.toLong() ?: client.officeId.toLong(),
         accountTypeId = QrCodeData.ACCOUNT_TYPE_ID,
-        accountExternalId = accountExternalId,
+        accountExternalId = selectedAccount?.externalId ?: accountExternalId,
         currency = "USD",
         amount = "",
     ),
     @Transient
     val dialogState: DialogState? = null,
 ) {
+    /**
+     * The currently active external ID, prioritizing selectedAccount over the stored accountExternalId.
+     */
+    val currentExternalId: String
+        get() = selectedAccount?.externalId ?: accountExternalId
+
     /**
      * Computed property for inter-bank QR data.
      * Simplified format: fspId + accountExternalId for participant lookup.
@@ -337,7 +425,7 @@ data class MpayQrState(
             amount = qrData.amount,
             accountId = 0L,
             currency = qrData.currency,
-            accountExternalId = accountExternalId,
+            accountExternalId = currentExternalId,
         )
 
     sealed interface ViewState {
@@ -347,7 +435,8 @@ data class MpayQrState(
 
         data class Content(
             val intraBankData: String,
-            val interBankData: String,
+            val interBankData: String?,
+            val interBankUnavailableReason: String? = null,
         ) : ViewState {
 
             private val logo: QrLogo
@@ -410,6 +499,11 @@ sealed interface MpayQrAction {
     data object NavigateBack : MpayQrAction
     data object ShowSetAmountDialog : MpayQrAction
     data object DismissDialog : MpayQrAction
+
+    // Account picker actions
+    data object ShowAccountPicker : MpayQrAction
+    data object DismissAccountPicker : MpayQrAction
+    data class SelectAccount(val account: Account) : MpayQrAction
 
     data class AmountChanged(val amount: String) : MpayQrAction
     data class CurrencyChanged(val currency: String) : MpayQrAction

--- a/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/components/AccountPickerBottomSheet.kt
+++ b/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/components/AccountPickerBottomSheet.kt
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2024 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+ */
+package org.mifospay.feature.mpay.qr.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import mobile_wallet.feature.mpay_qr.generated.resources.Res
+import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_has_external_id
+import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_no_external_id
+import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_select_account
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.mifospay.core.designsystem.icon.MifosIcons
+import org.mifospay.core.model.account.Account
+import org.mifospay.core.model.savingsaccount.Currency
+import org.mifospay.core.model.savingsaccount.Status
+import template.core.base.designsystem.KptMaterialTheme
+import template.core.base.designsystem.theme.KptTheme
+
+/**
+ * Bottom sheet for selecting an account for QR code generation.
+ * Shows all available accounts with indicators for external ID availability.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AccountPickerBottomSheet(
+    accounts: List<Account>,
+    selectedAccount: Account?,
+    onAccountSelected: (Account) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(),
+        containerColor = KptTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = KptTheme.spacing.md),
+        ) {
+            Text(
+                text = stringResource(Res.string.feature_mpay_qr_select_account),
+                style = KptTheme.typography.titleMedium,
+                color = KptTheme.colorScheme.onSurface,
+            )
+
+            Spacer(modifier = Modifier.height(KptTheme.spacing.md))
+
+            accounts.forEachIndexed { index, account ->
+                AccountPickerItem(
+                    account = account,
+                    isSelected = account.id == selectedAccount?.id,
+                    hasExternalId = !account.externalId.isNullOrBlank(),
+                    onClick = { onAccountSelected(account) },
+                )
+
+                if (index < accounts.lastIndex) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(vertical = KptTheme.spacing.xs),
+                        color = KptTheme.colorScheme.outlineVariant,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(KptTheme.spacing.lg))
+        }
+    }
+}
+
+@Composable
+private fun AccountPickerItem(
+    account: Account,
+    isSelected: Boolean,
+    hasExternalId: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(vertical = KptTheme.spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
+    ) {
+        RadioButton(
+            selected = isSelected,
+            onClick = onClick,
+        )
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = account.productName ?: account.name,
+                style = KptTheme.typography.bodyMedium,
+                color = KptTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = formatAccountDisplay(account.number),
+                style = KptTheme.typography.bodySmall,
+                color = KptTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        // External ID indicator
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
+        ) {
+            if (hasExternalId) {
+                Icon(
+                    imageVector = MifosIcons.Check,
+                    contentDescription = stringResource(Res.string.feature_mpay_qr_has_external_id),
+                    modifier = Modifier.size(KptTheme.spacing.md),
+                    tint = KptTheme.colorScheme.primary,
+                )
+            } else {
+                Icon(
+                    imageVector = MifosIcons.Info,
+                    contentDescription = stringResource(Res.string.feature_mpay_qr_no_external_id),
+                    modifier = Modifier.size(KptTheme.spacing.md),
+                    tint = KptTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Formats account number for display with masking.
+ * Example: "1234567890" -> "●●●● ●●●● 7890"
+ */
+private fun formatAccountDisplay(accountNo: String): String {
+    if (accountNo.length <= 4) return accountNo
+    val lastFour = accountNo.takeLast(4)
+    return "●●●● ●●●● $lastFour"
+}
+
+@Preview
+@Composable
+private fun AccountPickerItemPreview() {
+    KptMaterialTheme {
+        Column {
+            AccountPickerItem(
+                account = Account(
+                    id = 1,
+                    name = "Savings Account",
+                    number = "1234567890",
+                    balance = 1000.0,
+                    externalId = "EXT-123",
+                    productName = "Savings Account",
+                    currency = Currency(
+                        code = "USD",
+                        name = "US Dollar",
+                        decimalPlaces = 2,
+                        displaySymbol = "$",
+                        nameCode = "currency.USD",
+                        displayLabel = "US Dollar ($)",
+                    ),
+                    status = Status(
+                        id = 300,
+                        code = "active",
+                        value = "Active",
+                        submittedAndPendingApproval = false,
+                        approved = false,
+                        rejected = false,
+                        withdrawnByApplicant = false,
+                        active = true,
+                        closed = false,
+                        prematureClosed = false,
+                        transferInProgress = false,
+                        transferOnHold = false,
+                        matured = false,
+                    ),
+                ),
+                isSelected = true,
+                hasExternalId = true,
+                onClick = {},
+            )
+
+            HorizontalDivider()
+
+            AccountPickerItem(
+                account = Account(
+                    id = 2,
+                    name = "Current Account",
+                    number = "0987654321",
+                    balance = 500.0,
+                    externalId = null,
+                    productName = "Current Account",
+                    currency = Currency(
+                        code = "USD",
+                        name = "US Dollar",
+                        decimalPlaces = 2,
+                        displaySymbol = "$",
+                        nameCode = "currency.USD",
+                        displayLabel = "US Dollar ($)",
+                    ),
+                    status = Status(
+                        id = 300,
+                        code = "active",
+                        value = "Active",
+                        submittedAndPendingApproval = false,
+                        approved = false,
+                        rejected = false,
+                        withdrawnByApplicant = false,
+                        active = true,
+                        closed = false,
+                        prematureClosed = false,
+                        transferInProgress = false,
+                        transferOnHold = false,
+                        matured = false,
+                    ),
+                ),
+                isSelected = false,
+                hasExternalId = false,
+                onClick = {},
+            )
+        }
+    }
+}

--- a/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/components/AccountSelectorCard.kt
+++ b/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/components/AccountSelectorCard.kt
@@ -11,6 +11,7 @@ package org.mifospay.feature.mpay.qr.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -51,6 +52,7 @@ import template.core.base.designsystem.theme.KptTheme
  * - Office/bank name
  * - Masked account number
  * - "Primary" badge with checkmark
+ * - Dropdown indicator when multiple accounts available
  */
 @Composable
 internal fun AccountSelectorCard(
@@ -58,9 +60,19 @@ internal fun AccountSelectorCard(
     account: DefaultAccount,
     isPrimary: Boolean,
     modifier: Modifier = Modifier,
+    hasMultipleAccounts: Boolean = false,
+    onClick: (() -> Unit)? = null,
 ) {
     Card(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .then(
+                if (onClick != null && hasMultipleAccounts) {
+                    Modifier.clickable { onClick() }
+                } else {
+                    Modifier
+                },
+            ),
         colors = CardDefaults.cardColors(
             containerColor = KptTheme.colorScheme.surfaceContainerLow,
         ),
@@ -134,6 +146,16 @@ internal fun AccountSelectorCard(
                     style = KptTheme.typography.bodySmall,
                     fontWeight = FontWeight.Medium,
                     color = KptTheme.colorScheme.primary,
+                )
+            }
+
+            // Dropdown indicator when multiple accounts available
+            if (hasMultipleAccounts) {
+                Icon(
+                    imageVector = MifosIcons.KeyboardArrowDown,
+                    contentDescription = "Select account",
+                    modifier = Modifier.size(KptTheme.spacing.lg),
+                    tint = KptTheme.colorScheme.onSurfaceVariant,
                 )
             }
 

--- a/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/components/InterBankPlaceholder.kt
+++ b/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/components/InterBankPlaceholder.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+ */
+package org.mifospay.feature.mpay.qr.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import mobile_wallet.feature.mpay_qr.generated.resources.Res
+import mobile_wallet.feature.mpay_qr.generated.resources.feature_mpay_qr_inter_bank_unavailable
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.mifospay.core.designsystem.icon.MifosIcons
+import template.core.base.designsystem.KptMaterialTheme
+import template.core.base.designsystem.theme.KptTheme
+
+/**
+ * Placeholder card shown when Inter-Bank QR code cannot be generated.
+ * Displays a humanized message explaining why the QR code is unavailable
+ * and what the user can do to enable it.
+ */
+@Composable
+internal fun InterBankPlaceholder(
+    reason: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .aspectRatio(1f),
+        colors = CardDefaults.cardColors(
+            containerColor = KptTheme.colorScheme.surfaceVariant,
+        ),
+        shape = KptTheme.shapes.large,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(KptTheme.spacing.lg),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = MifosIcons.Info,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = KptTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(KptTheme.spacing.md))
+
+            Text(
+                text = stringResource(Res.string.feature_mpay_qr_inter_bank_unavailable),
+                style = KptTheme.typography.titleMedium,
+                color = KptTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
+
+            Text(
+                text = reason,
+                style = KptTheme.typography.bodyMedium,
+                color = KptTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun InterBankPlaceholderPreview() {
+    KptMaterialTheme {
+        InterBankPlaceholder(
+            reason = "Your account doesn't have an external ID configured. Contact your bank to enable inter-bank transfers.",
+        )
+    }
+}

--- a/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/di/MpayQrModule.kt
+++ b/feature/mpay-qr/src/commonMain/kotlin/org/mifospay/feature/mpay/qr/di/MpayQrModule.kt
@@ -19,6 +19,7 @@ val MpayQrModule = module {
         MpayQrViewModel(
             localRepository = get(),
             repository = get(),
+            accountRepository = get(),
             savedStateHandle = get(),
             ioDispatcher = get(named(MifosDispatchers.IO.name)),
         )

--- a/feature/payments/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/payments/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2024 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+-->
+<resources>
+    <!-- Payments Tab Labels -->
+    <string name="feature_payments_vpa">عنوان الدفع الافتراضي (VPA)</string>
+    <string name="feature_payments_mobile_number">رقم الهاتف المحمول</string>
+    <string name="feature_payments_receive">استلام</string>
+    <string name="feature_payments_show_code">إظهار الرمز</string>
+    <string name="feature_payments_send">إرسال</string>
+    <string name="feature_payments_request">طلب</string>
+    <string name="feature_payments_history">السجل</string>
+    <string name="feature_payments_select_transfer_type_header">كيف ترغب في إجراء\nهذا التحويل؟</string>
+    <string name="feature_payments_select_transfer_type_subtitle">اختر طريقة التحويل أدناه</string>
+    <string name="feature_payments_intra_bank_transfer_title">تحويل داخل البنك</string>
+    <string name="feature_payments_intra_bank_transfer_description">نقل الأموال بين الحسابات داخل هذا البنك.</string>
+    <string name="feature_payments_inter_bank_transfer_title">تحويل بين البنوك</string>
+    <string name="feature_payments_inter_bank_transfer_description">إرسال الأموال إلى حسابات في بنوك مختلفة.</string>
+    <string name="feature_payments_transfer_options_title">خيارات التحويل</string>
+</resources>

--- a/feature/payments/src/commonMain/composeResources/values-bn/strings.xml
+++ b/feature/payments/src/commonMain/composeResources/values-bn/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2024 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+-->
+<resources>
+    <!-- Payments Tab Labels -->
+    <string name="feature_payments_vpa">ভার্চুয়াল পেমেন্ট ঠিকানা (VPA)</string>
+    <string name="feature_payments_mobile_number">মোবাইল নম্বর</string>
+    <string name="feature_payments_receive">গ্রহণ করুন</string>
+    <string name="feature_payments_show_code">কোড দেখান</string>
+    <string name="feature_payments_send">পাঠান</string>
+    <string name="feature_payments_request">অনুরোধ করুন</string>
+    <string name="feature_payments_history">ইতিহাস</string>
+    <string name="feature_payments_select_transfer_type_header">আপনি কীভাবে এই\nস্থানান্তরটি করতে চান?</string>
+    <string name="feature_payments_select_transfer_type_subtitle">নিচের একটি স্থানান্তর পদ্ধতি বেছে নিন</string>
+    <string name="feature_payments_intra_bank_transfer_title">আন্তঃ-ব্যাংক স্থানান্তর (একই ব্যাংক)</string>
+    <string name="feature_payments_intra_bank_transfer_description">এই ব্যাংকের ভিতরের অ্যাকাউন্টগুলির মধ্যে তহবিল সরান।</string>
+    <string name="feature_payments_inter_bank_transfer_title">আন্তঃ-ব্যাংক স্থানান্তর (অন্য ব্যাংক)</string>
+    <string name="feature_payments_inter_bank_transfer_description">বিভিন্ন ব্যাংকের অ্যাকাউন্টে তহবিল পাঠান।</string>
+    <string name="feature_payments_transfer_options_title">স্থানান্তরের বিকল্পগুলি</string>
+</resources>

--- a/feature/payments/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/payments/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2024 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+-->
+<resources>
+    <!-- Payments Tab Labels -->
+    <string name="feature_payments_vpa">Dirección de Pago Virtual (VPA)</string>
+    <string name="feature_payments_mobile_number">Número de teléfono</string>
+    <string name="feature_payments_receive">Recibir</string>
+    <string name="feature_payments_show_code">Mostrar código</string>
+    <string name="feature_payments_send">Enviar</string>
+    <string name="feature_payments_request">Solicitar</string>
+    <string name="feature_payments_history">Historial</string>
+    <string name="feature_payments_select_transfer_type_header">¿Cómo le gustaría realizar\nesta transferencia?</string>
+    <string name="feature_payments_select_transfer_type_subtitle">Elija un método de transferencia a continuación</string>
+    <string name="feature_payments_intra_bank_transfer_title">Transferencia intrabancaria</string>
+    <string name="feature_payments_intra_bank_transfer_description">Mueva fondos entre cuentas dentro de este banco.</string>
+    <string name="feature_payments_inter_bank_transfer_title">Transferencia interbancaria</string>
+    <string name="feature_payments_inter_bank_transfer_description">Envíe fondos a cuentas en diferentes bancos.</string>
+    <string name="feature_payments_transfer_options_title">Opciones de transferencia</string>
+</resources>

--- a/feature/payments/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/payments/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2024 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+-->
+<resources>
+    <!-- Payments Tab Labels -->
+    <string name="feature_payments_vpa">Adresse de paiement virtuelle (VPA)</string>
+    <string name="feature_payments_mobile_number">Numéro de mobile</string>
+    <string name="feature_payments_receive">Recevoir</string>
+    <string name="feature_payments_show_code">Afficher le code</string>
+    <string name="feature_payments_send">Envoyer</string>
+    <string name="feature_payments_request">Demander</string>
+    <string name="feature_payments_history">Historique</string>
+    <string name="feature_payments_select_transfer_type_header">Comment souhaitez-vous effectuer\ncette transaction ?</string>
+    <string name="feature_payments_select_transfer_type_subtitle">Choisissez une méthode de transfert ci-dessous</string>
+    <string name="feature_payments_intra_bank_transfer_title">Transfert intra-bancaire</string>
+    <string name="feature_payments_intra_bank_transfer_description">Déplacez des fonds entre les comptes de cette banque.</string>
+    <string name="feature_payments_inter_bank_transfer_title">Transfert inter-bancaire</string>
+    <string name="feature_payments_inter_bank_transfer_description">Envoyez des fonds vers des comptes de différentes banques.</string>
+    <string name="feature_payments_transfer_options_title">Options de transfert</string>
+</resources>

--- a/feature/payments/src/commonMain/composeResources/values-hi/strings.xml
+++ b/feature/payments/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2024 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+-->
+<resources>
+    <!-- Payments Tab Labels -->
+    <string name="feature_payments_vpa">वर्चुअल पेमेंट एड्रेस (VPA)</string>
+    <string name="feature_payments_mobile_number">मोबाइल नंबर</string>
+    <string name="feature_payments_receive">प्राप्त करें</string>
+    <string name="feature_payments_show_code">कोड दिखाएं</string>
+    <string name="feature_payments_send">भेजें</string>
+    <string name="feature_payments_request">अनुरोध करें</string>
+    <string name="feature_payments_history">इतिहास</string>
+    <string name="feature_payments_select_transfer_type_header">आप यह ट्रांसफ़र\nकैसे करना चाहेंगे?</string>
+    <string name="feature_payments_select_transfer_type_subtitle">नीचे एक ट्रांसफ़र तरीका चुनें</string>
+    <string name="feature_payments_intra_bank_transfer_title">इंट्रा-बैंक ट्रांसफ़र</string>
+    <string name="feature_payments_intra_bank_transfer_description">इस बैंक के खातों के बीच धनराशि स्थानांतरित करें।</string>
+    <string name="feature_payments_inter_bank_transfer_title">इंटर-बैंक ट्रांसफ़र</string>
+    <string name="feature_payments_inter_bank_transfer_description">विभिन्न बैंकों के खातों में धनराशि भेजें।</string>
+    <string name="feature_payments_transfer_options_title">ट्रांसफ़र विकल्प</string>
+</resources>

--- a/feature/payments/src/commonMain/composeResources/values-id/strings.xml
+++ b/feature/payments/src/commonMain/composeResources/values-id/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2024 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+-->
+<resources>
+    <!-- Payments Tab Labels -->
+    <string name="feature_payments_vpa">Alamat Pembayaran Virtual (VPA)</string>
+    <string name="feature_payments_mobile_number">Nomor Ponsel</string>
+    <string name="feature_payments_receive">Terima</string>
+    <string name="feature_payments_show_code">Tampilkan kode</string>
+    <string name="feature_payments_send">Kirim</string>
+    <string name="feature_payments_request">Minta</string>
+    <string name="feature_payments_history">Riwayat</string>
+    <string name="feature_payments_select_transfer_type_header">Bagaimana Anda ingin melakukan transfer ini?</string>
+    <string name="feature_payments_select_transfer_type_subtitle">Pilih metode transfer di bawah</string>
+    <string name="feature_payments_intra_bank_transfer_title">Transfer Intrabank</string>
+    <string name="feature_payments_intra_bank_transfer_description">Pindahkan dana antar rekening di dalam bank ini.</string>
+    <string name="feature_payments_inter_bank_transfer_title">Transfer Antarbank</string>
+    <string name="feature_payments_inter_bank_transfer_description">Kirim dana ke rekening di bank yang berbeda.</string>
+    <string name="feature_payments_transfer_options_title">Opsi Transfer</string>
+</resources>

--- a/feature/payments/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/payments/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2024 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+-->
+<resources>
+    <!-- Payments Tab Labels -->
+    <string name="feature_payments_vpa">Endereço de Pagamento Virtual (VPA)</string>
+    <string name="feature_payments_mobile_number">Número de Telemóvel</string>
+    <string name="feature_payments_receive">Receber</string>
+    <string name="feature_payments_show_code">Mostrar código</string>
+    <string name="feature_payments_send">Enviar</string>
+    <string name="feature_payments_request">Solicitar</string>
+    <string name="feature_payments_history">Histórico</string>
+    <string name="feature_payments_select_transfer_type_header">Como gostaria de fazer\nesta transferência?</string>
+    <string name="feature_payments_select_transfer_type_subtitle">Escolha um método de transferência abaixo</string>
+    <string name="feature_payments_intra_bank_transfer_title">Transferência Intrabancária</string>
+    <string name="feature_payments_intra_bank_transfer_description">Mova fundos entre contas dentro deste banco.</string>
+    <string name="feature_payments_inter_bank_transfer_title">Transferência Interbancária</string>
+    <string name="feature_payments_inter_bank_transfer_description">Envie fundos para contas em bancos diferentes.</string>
+    <string name="feature_payments_transfer_options_title">Opções de Transferência</string>
+</resources>

--- a/feature/payments/src/commonMain/composeResources/values-sw/strings.xml
+++ b/feature/payments/src/commonMain/composeResources/values-sw/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2024 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+-->
+<resources>
+    <!-- Payments Tab Labels -->
+    <string name="feature_payments_vpa">Anwani ya Malipo ya Mtandaoni (VPA)</string>
+    <string name="feature_payments_mobile_number">Nambari ya Simu</string>
+    <string name="feature_payments_receive">Pokea</string>
+    <string name="feature_payments_show_code">Onyesha msimbo</string>
+    <string name="feature_payments_send">Tuma</string>
+    <string name="feature_payments_request">Omba</string>
+    <string name="feature_payments_history">Historia</string>
+    <string name="feature_payments_select_transfer_type_header">Ungependa kufanya\nuhamisho huu vipi?</string>
+    <string name="feature_payments_select_transfer_type_subtitle">Chagua njia ya uhamisho hapa chini</string>
+    <string name="feature_payments_intra_bank_transfer_title">Uhamisho Ndani ya Benki</string>
+    <string name="feature_payments_intra_bank_transfer_description">Hamisha fedha kati ya akaunti ndani ya benki hii.</string>
+    <string name="feature_payments_inter_bank_transfer_title">Uhamisho Kati ya Benki</string>
+    <string name="feature_payments_inter_bank_transfer_description">Tuma fedha kwenye akaunti katika benki tofauti.</string>
+    <string name="feature_payments_transfer_options_title">Chaguzi za Uhamisho</string>
+</resources>


### PR DESCRIPTION
## Summary
- Add AccountRepository dependency for fetching user accounts
- Add account picker bottom sheet with account selection UI
- Show external ID status indicator for inter-bank QR support
- Allow users to select which wallet account to generate QR codes for

## Test plan
- [ ] Open QR generation screen with multiple accounts
- [ ] Tap account selector card to open account picker
- [ ] Select different account and verify QR updates
- [ ] Verify external ID indicator shows correctly for each account
- [ ] Test both intra-bank and inter-bank QR tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account selection functionality for QR code generation with a bottom sheet picker.
  * Introduced inter-bank transfer QR code support with external ID requirements and fallback messaging.
  * Added visual account selector with dropdown indicator when multiple accounts are available.

* **Documentation**
  * Extended multi-language support for payments feature with translations in Arabic, Bengali, Spanish, French, Hindi, Indonesian, Portuguese, and Swahili.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->