### PR TITLE
MW-SEC-015: disable backup in AndroidManifest

### DIFF
--- a/cmp-android/src/main/AndroidManifest.xml
+++ b/cmp-android/src/main/AndroidManifest.xml
@@ -34,7 +34,9 @@
 
     <application
         android:name=".MifosPayApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/cmp-android/src/main/res/xml/data_extraction_rules.xml
+++ b/cmp-android/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2024 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-wallet/blob/master/LICENSE.md
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
closes #1981

set allowBackup to false and added dataExtractionRules 
for Android 12+ to prevent sensitive data from being backed up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified application backup behavior settings. Added configuration for data extraction rules to control which data is handled during cloud backups and device transfer operations. Specific data categories are now excluded from backup and extraction processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->