### PR TITLE
feat(settings): Fix settings to use savings accountId for disabling accounts

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/mifospay/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifospay/feature/settings/SettingsViewModel.kt
@@ -225,13 +225,20 @@ class SettingsViewModel(
     }
 
     private fun handleDisableAccount() {
+        val accountId = userPreferencesRepository.defaultAccountId.value
+        if (accountId == null) {
+            mutableStateFlow.update {
+                it.copy(dialogState = DialogState.Error("Default account not available"))
+            }
+            return
+        }
+
         mutableStateFlow.update {
             it.copy(dialogState = DialogState.Loading)
         }
 
-        // TODO:: this shouldn't work, we need account id to block account
         viewModelScope.launch {
-            val result = repository.blockAccount(state.client.id)
+            val result = repository.blockAccount(accountId)
             sendAction(DisableAccountResult(result))
         }
     }


### PR DESCRIPTION
…ing account

## Issue Fix
Fixes #2013 
Jira Task: [Task_Number](Task_Link)

## Screenshots
<img width="925" height="418" alt="image" src="https://github.com/user-attachments/assets/2c59f4c0-aeeb-4842-bcf3-58ed528065b0" />

## Description
* Read the default savings account id from preferences in the settings disable flow.
* Show a clear error if the default account is missing.
* Call block with the correct account id.

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced account disabling feature to use default account preference with improved error handling for edge cases where account information may be unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->