### PR TITLE
fix: prevent NPE crash in FastMpay bank mismatch and amount confirmation sheets

### DIFF
--- a/feature/fast-mpay/src/commonMain/kotlin/org/mifospay/feature/fastmpay/FastMpayScreen.kt
+++ b/feature/fast-mpay/src/commonMain/kotlin/org/mifospay/feature/fastmpay/FastMpayScreen.kt
@@ -190,8 +190,8 @@ fun FastMpayScreen(
     }
 
     // Bank mismatch info bottom sheet
-    if (showBankMismatchSheet && bankMismatchData != null) {
-        val mismatchData = bankMismatchData!!
+    val mismatchData = bankMismatchData
+    if (showBankMismatchSheet && mismatchData != null) {
         InfoBottomSheet(
             title = stringResource(Res.string.core_ui_different_bank_title),
             message = stringResource(Res.string.core_ui_different_bank_message),
@@ -242,8 +242,8 @@ fun FastMpayScreen(
     }
 
     // Amount confirmation bottom sheet
-    if (showAmountConfirmation && pendingAmountConfirmation != null) {
-        val pending = pendingAmountConfirmation!!
+    val pending = pendingAmountConfirmation
+    if (showAmountConfirmation && pending != null) {
         val (amount, currency) = when (pending) {
             is PendingAmountConfirmation.MakeTransfer -> {
                 pending.qrData.amount to pending.qrData.currency


### PR DESCRIPTION

## Description

The `FastMpayScreen` contained two unsafe non-null assertions (`!!`) on nullable mutable Compose state variables inside conditional null checks.

Because `bankMismatchData` and `pendingAmountConfirmation` are mutable `var` Compose states, recomposition could occur between the null check and the `!!` dereference, causing the value to become `null` mid-execution and resulting in a `NullPointerException`.

### Affected Scenarios

* Scanning a QR code from a different bank → bank mismatch bottom sheet
* Scanning a QR code with a pre-filled amount → amount confirmation sheet

### Fix
Fixes #2023 
Replaced unsafe `!!` assertions by snapshotting nullable mutable state into local immutable `val` variables before the conditional checks.

This allows Kotlin smart casts to safely guarantee non-null values inside the block and removes the need for `!!`.

```kotlin
// Before (unsafe)
if (showBankMismatchSheet && bankMismatchData != null) {
    val mismatchData = bankMismatchData!! // crash risk
}

// After (safe)
val mismatchData = bankMismatchData
if (showBankMismatchSheet && mismatchData != null) {
    // smart cast — no !! needed
}
```

### Changes

* `FastMpayScreen.kt`

  * Replaced 2 unsafe `!!` assertions with safe local `val` snapshots

### Testing

* All existing unit tests pass:

  * `FastMpayProcessorTest` × 15
  * `FastMpayViewModelTest` × 9

### Platforms Affected

* Android
* Desktop
* Web

(all Compose targets)

##

<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

* [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

* [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

* [x] If you have multiple commits please combine them into one commit by squashing them.