### PR TITLE
MM-573: Sanitize tenant and auth headers to prevent header injection

### DIFF
--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/config/InstanceConfigManager.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/config/InstanceConfigManager.kt
@@ -19,6 +19,9 @@ class InstanceConfigManager(
     private val userPreferencesRepository: UserPreferencesRepository,
 ) : MultiUrlConfigProvider {
     companion object {
+        private const val MAX_TENANT_ID_LENGTH = 64
+        private val VALID_TENANT_ID_REGEX = Regex("^[A-Za-z0-9_-]+$")
+
         // Default main instance configuration
         private val DEFAULT_MAIN_INSTANCE = ServerInstance(
             endpoint = "mifos-bank-2.mifos.community",
@@ -68,7 +71,7 @@ class InstanceConfigManager(
 
     fun getPath(): String = getCurrentInstance().path
 
-    fun getPlatformTenantId(): String = getCurrentInstance().platformTenantId
+    fun getPlatformTenantId(): String = sanitizeTenantId(getCurrentInstance().platformTenantId)
 
     fun getUrl(): String = getCurrentInstance().fullUrl
 
@@ -90,4 +93,18 @@ class InstanceConfigManager(
         getEndpoint(),
         getCurrentInterbankInstance().endpoint,
     )
+
+    private fun sanitizeTenantId(rawTenantId: String): String {
+        val normalized = rawTenantId
+            .trim()
+            .replace("\r", "")
+            .replace("\n", "")
+            .take(MAX_TENANT_ID_LENGTH)
+
+        return if (normalized.isNotEmpty() && VALID_TENANT_ID_REGEX.matches(normalized)) {
+            normalized
+        } else {
+            DEFAULT_MAIN_INSTANCE.platformTenantId
+        }
+    }
 }

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/KtorInterceptor.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/KtorInterceptor.kt
@@ -35,8 +35,9 @@ class KtorInterceptor(
                 context.header(BaseURL.HEADER_TENANT, plugin.configManager.getPlatformTenantId())
 
                 plugin.getToken()?.let { token ->
-                    if (token.isNotEmpty()) {
-                        context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $token"
+                    val sanitizedToken = sanitizeHeaderValue(token)
+                    if (sanitizedToken.isNotEmpty()) {
+                        context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $sanitizedToken"
                     }
                 }
             }
@@ -78,8 +79,9 @@ class KtorInterceptorRe(
                 context.header(BaseURL.HEADER_TENANT, plugin.configManager.getPlatformTenantId())
 
                 token?.let { token ->
-                    if (token.isNotEmpty()) {
-                        context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $token"
+                    val sanitizedToken = sanitizeHeaderValue(token)
+                    if (sanitizedToken.isNotEmpty()) {
+                        context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $sanitizedToken"
                     }
                 }
             }
@@ -102,4 +104,11 @@ class KtorInterceptorRe(
 class ConfigRe {
     lateinit var repository: UserPreferencesRepository
     lateinit var configManager: InstanceConfigManager
+}
+
+private fun sanitizeHeaderValue(value: String): String {
+    return value
+        .trim()
+        .replace("\r", "")
+        .replace("\n", "")
 }


### PR DESCRIPTION
hi @therajanmaurya sir

This PR introduces a focused security hardening update in the network layer for MM-573 (Cipher 2026 remediation).
It sanitizes dynamic header values before request injection to reduce malformed-input and header-injection risk.

Changes included
Updated core/network/src/commonMain/kotlin/org/mifospay/core/network/config/InstanceConfigManager.kt

Sanitized platformTenantId in getPlatformTenantId()
Added normalization: trim, remove CR/LF, apply max length cap
Enforced tenant format: [A-Za-z0-9_-]+
Added safe fallback to default tenant when value is empty/invalid
Updated core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/KtorInterceptor.kt

Added sanitizeHeaderValue() helper
Sanitized token before setting Authorization header in both interceptor paths
Skipped Authorization header when sanitized token becomes empty
Why this change
Prevents CR/LF-based header injection vectors in tenant/token values
Improves robustness when config or stored token data is malformed
Keeps scope intentionally small and low-risk for fast review
Validation
IDE lint checks on edited files passed (no new lint issues)
Full build/test execution was not run in this environment due to missing JAVA_HOME