### PR TITLE
MM-573: Harden dynamic network config and authorization header handling

### DIFF
--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/config/InstanceConfigManager.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/config/InstanceConfigManager.kt
@@ -19,6 +19,9 @@ class InstanceConfigManager(
     private val userPreferencesRepository: UserPreferencesRepository,
 ) : MultiUrlConfigProvider {
     companion object {
+        private const val MAX_TENANT_ID_LENGTH = 64
+        private val VALID_TENANT_ID_REGEX = Regex("^[A-Za-z0-9_-]+$")
+
         // Default main instance configuration
         private val DEFAULT_MAIN_INSTANCE = ServerInstance(
             endpoint = "mifos-bank-2.mifos.community",
@@ -68,7 +71,7 @@ class InstanceConfigManager(
 
     fun getPath(): String = getCurrentInstance().path
 
-    fun getPlatformTenantId(): String = getCurrentInstance().platformTenantId
+    fun getPlatformTenantId(): String = sanitizeTenantId(getCurrentInstance().platformTenantId)
 
     fun getUrl(): String = getCurrentInstance().fullUrl
 
@@ -90,4 +93,18 @@ class InstanceConfigManager(
         getEndpoint(),
         getCurrentInterbankInstance().endpoint,
     )
+
+    private fun sanitizeTenantId(rawTenantId: String): String {
+        val normalized = rawTenantId
+            .trim()
+            .replace("\r", "")
+            .replace("\n", "")
+            .take(MAX_TENANT_ID_LENGTH)
+
+        return if (normalized.isNotEmpty() && VALID_TENANT_ID_REGEX.matches(normalized)) {
+            normalized
+        } else {
+            DEFAULT_MAIN_INSTANCE.platformTenantId
+        }
+    }
 }

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/config/InstanceConfigManager.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/config/InstanceConfigManager.kt
@@ -20,7 +20,12 @@ class InstanceConfigManager(
 ) : MultiUrlConfigProvider {
     companion object {
         private const val MAX_TENANT_ID_LENGTH = 64
+        private const val MAX_ENDPOINT_LENGTH = 255
+        private const val MAX_PATH_LENGTH = 256
         private val VALID_TENANT_ID_REGEX = Regex("^[A-Za-z0-9_-]+$")
+        private val VALID_ENDPOINT_REGEX = Regex("^[A-Za-z0-9.-]+$")
+        private val VALID_PATH_REGEX = Regex("^/[A-Za-z0-9_./-]*/$")
+        private val VALID_PROTOCOLS = setOf("https://")
 
         // Default main instance configuration
         private val DEFAULT_MAIN_INSTANCE = ServerInstance(
@@ -65,22 +70,27 @@ class InstanceConfigManager(
             ?: DEFAULT_INTERBANK_INSTANCE
     }
 
-    fun getEndpoint(): String = getCurrentInstance().endpoint
+    fun getEndpoint(): String = sanitizeEndpoint(getCurrentInstance().endpoint)
 
-    fun getProtocol(): String = getCurrentInstance().protocol
+    fun getProtocol(): String = sanitizeProtocol(getCurrentInstance().protocol)
 
-    fun getPath(): String = getCurrentInstance().path
+    fun getPath(): String = sanitizePath(getCurrentInstance().path)
 
     fun getPlatformTenantId(): String = sanitizeTenantId(getCurrentInstance().platformTenantId)
 
-    fun getUrl(): String = getCurrentInstance().fullUrl
+    fun getUrl(): String = "${getProtocol()}${getEndpoint()}${getPath()}"
 
     fun getSelfServiceUrl(): String {
-        val instance = getCurrentInstance()
-        return "${instance.protocol}${instance.endpoint}${instance.path}self/"
+        return "${getProtocol()}${getEndpoint()}${getPath()}self/"
     }
 
-    fun getInterbankUrl(): String = getCurrentInterbankInstance().fullUrl
+    fun getInterbankUrl(): String {
+        val interbank = getCurrentInterbankInstance()
+        val protocol = sanitizeProtocol(interbank.protocol)
+        val endpoint = sanitizeEndpoint(interbank.endpoint)
+        val path = sanitizePath(interbank.path)
+        return "$protocol$endpoint$path"
+    }
 
     // MultiUrlConfigProvider implementation
     override fun getBaseUrl(type: MultiUrlConfigProvider.UrlType): String = when (type) {
@@ -91,7 +101,7 @@ class InstanceConfigManager(
 
     override fun getLoggableHosts(): List<String> = listOf(
         getEndpoint(),
-        getCurrentInterbankInstance().endpoint,
+        sanitizeEndpoint(getCurrentInterbankInstance().endpoint),
     )
 
     private fun sanitizeTenantId(rawTenantId: String): String {
@@ -105,6 +115,39 @@ class InstanceConfigManager(
             normalized
         } else {
             DEFAULT_MAIN_INSTANCE.platformTenantId
+        }
+    }
+
+    private fun sanitizeEndpoint(rawEndpoint: String): String {
+        val normalized = rawEndpoint
+            .trim()
+            .replace("\r", "")
+            .replace("\n", "")
+            .take(MAX_ENDPOINT_LENGTH)
+
+        return if (normalized.isNotEmpty() && VALID_ENDPOINT_REGEX.matches(normalized)) {
+            normalized
+        } else {
+            DEFAULT_MAIN_INSTANCE.endpoint
+        }
+    }
+
+    private fun sanitizeProtocol(rawProtocol: String): String {
+        val normalized = rawProtocol.trim().lowercase()
+        return if (normalized in VALID_PROTOCOLS) normalized else DEFAULT_MAIN_INSTANCE.protocol
+    }
+
+    private fun sanitizePath(rawPath: String): String {
+        val normalized = rawPath
+            .trim()
+            .replace("\r", "")
+            .replace("\n", "")
+            .take(MAX_PATH_LENGTH)
+
+        return if (normalized.isNotEmpty() && VALID_PATH_REGEX.matches(normalized)) {
+            normalized
+        } else {
+            DEFAULT_MAIN_INSTANCE.path
         }
     }
 }

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/KtorInterceptor.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/KtorInterceptor.kt
@@ -35,8 +35,9 @@ class KtorInterceptor(
                 context.header(BaseURL.HEADER_TENANT, plugin.configManager.getPlatformTenantId())
 
                 plugin.getToken()?.let { token ->
-                    if (token.isNotEmpty()) {
-                        context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $token"
+                    val sanitizedToken = sanitizeHeaderValue(token)
+                    if (sanitizedToken.isNotEmpty()) {
+                        context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $sanitizedToken"
                     }
                 }
             }
@@ -78,8 +79,9 @@ class KtorInterceptorRe(
                 context.header(BaseURL.HEADER_TENANT, plugin.configManager.getPlatformTenantId())
 
                 token?.let { token ->
-                    if (token.isNotEmpty()) {
-                        context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $token"
+                    val sanitizedToken = sanitizeHeaderValue(token)
+                    if (sanitizedToken.isNotEmpty()) {
+                        context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $sanitizedToken"
                     }
                 }
             }
@@ -102,4 +104,11 @@ class KtorInterceptorRe(
 class ConfigRe {
     lateinit var repository: UserPreferencesRepository
     lateinit var configManager: InstanceConfigManager
+}
+
+private fun sanitizeHeaderValue(value: String): String {
+    return value
+        .trim()
+        .replace("\r", "")
+        .replace("\n", "")
 }

--- a/core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/KtorInterceptor.kt
+++ b/core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/KtorInterceptor.kt
@@ -36,7 +36,7 @@ class KtorInterceptor(
 
                 plugin.getToken()?.let { token ->
                     val sanitizedToken = sanitizeHeaderValue(token)
-                    if (sanitizedToken.isNotEmpty()) {
+                    if (sanitizedToken.isNotEmpty() && shouldAttachAuthorizationHeader(context.url.host, context.url.protocol.name)) {
                         context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $sanitizedToken"
                     }
                 }
@@ -80,7 +80,7 @@ class KtorInterceptorRe(
 
                 token?.let { token ->
                     val sanitizedToken = sanitizeHeaderValue(token)
-                    if (sanitizedToken.isNotEmpty()) {
+                    if (sanitizedToken.isNotEmpty() && shouldAttachAuthorizationHeader(context.url.host, context.url.protocol.name)) {
                         context.headers[BaseURL.HEADER_AUTHORIZATION] = "Basic $sanitizedToken"
                     }
                 }
@@ -111,4 +111,14 @@ private fun sanitizeHeaderValue(value: String): String {
         .trim()
         .replace("\r", "")
         .replace("\n", "")
+}
+
+private fun shouldAttachAuthorizationHeader(host: String, protocolName: String): Boolean {
+    return protocolName.equals("https", ignoreCase = true) || isLocalDevelopmentHost(host)
+}
+
+private fun isLocalDevelopmentHost(host: String): Boolean {
+    return host.equals("localhost", ignoreCase = true) ||
+        host == "127.0.0.1" ||
+        host == "10.0.2.2"
 }

--- a/docs/security/network-hardening-mm573.md
+++ b/docs/security/network-hardening-mm573.md
@@ -1,0 +1,33 @@
+## MM-573 Network Hardening Notes
+
+This document captures the security hardening added to dynamic network configuration and request headers in `mifos-pay`.
+
+### Why this change
+
+The app reads instance configuration (protocol, endpoint, path, tenant) dynamically. Without strict validation, malformed values can produce unsafe request targets or unsafe header values.
+
+### What was hardened
+
+- Sanitized tenant ID before adding `Fineract-Platform-TenantId` header.
+- Sanitized Authorization token values before header insertion.
+- Enforced HTTPS-only protocol from dynamic config (invalid protocol falls back to default secure instance).
+- Sanitized endpoint and path from dynamic config before URL construction.
+- Added safe defaults for invalid protocol/endpoint/path/tenant values.
+- Restricted auth header attachment to HTTPS requests (local dev hosts allowed for emulator/local testing).
+
+### Scope in code
+
+- `core/network/src/commonMain/kotlin/org/mifospay/core/network/config/InstanceConfigManager.kt`
+- `core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/KtorInterceptor.kt`
+
+### Security impact
+
+- Reduces header injection risk from CR/LF in tenant/token values.
+- Reduces risk of accidental insecure transport due to malformed instance protocol.
+- Prevents malformed endpoint/path values from being used directly in request URL generation.
+
+### Follow-up items
+
+- Add shared KMP unit tests for sanitizers in `core/network`.
+- Add telemetry for invalid instance config fallbacks (without logging sensitive values).
+- Evaluate certificate pinning integration in the HTTP stack as part of high-severity items.


### PR DESCRIPTION
hi @therajanmaurya 

This PR strengthens network-layer security remediation for MM-573 by hardening how dynamic instance configuration and request headers are handled before outbound API calls.

What changed
Added strict sanitization and fallback handling for dynamic instance values in InstanceConfigManager:
platformTenantId validation and CR/LF stripping
endpoint sanitization
path sanitization
protocol enforcement to secure default (https://) on invalid values
Updated URL construction to use sanitized protocol/host/path for:
main URL
self-service URL
interbank URL
Hardened KtorInterceptor authorization behavior:
sanitize token header value before use
attach Authorization only for HTTPS requests (with local-dev host exceptions)
Added remediation documentation:
docs/security/network-hardening-mm573.md
Security impact
Reduces header injection risk via CR/LF in tenant/token values.
Prevents malformed dynamic instance config from directly shaping unsafe URLs.
Reduces risk of token exposure on insecure transport by restricting auth-header attachment.
Scope
core/network/src/commonMain/kotlin/org/mifospay/core/network/config/InstanceConfigManager.kt
core/network/src/commonMain/kotlin/org/mifospay/core/network/utils/KtorInterceptor.kt
docs/security/network-hardening-mm573.md