### PR TITLE
fix(standing-instruction): reject non-positive and non-numeric amounts

### DIFF
--- a/feature/standing-instruction/src/commonMain/kotlin/org/mifospay/feature/standing/instruction/createOrUpdate/AddEditSIViewModel.kt
+++ b/feature/standing-instruction/src/commonMain/kotlin/org/mifospay/feature/standing/instruction/createOrUpdate/AddEditSIViewModel.kt
@@ -229,8 +229,8 @@ internal class AddEditSIViewModel(
                 data.name.isBlank() && state.isAddMode -> showError("Name is Required")
 
                 data.amount.isBlank() && state.isAddMode -> showError("Amount is Required")
-                data.amount.any { !it.isDigit() } && state.isAddMode -> showError("Amount is Invalid")
-                data.amount.toDoubleOrNull() == null && state.isAddMode -> showError("Amount is Required")
+                data.amount.toDoubleOrNull() == null && state.isAddMode -> showError("Amount is Invalid")
+                data.amount.toDouble() <= 0 && state.isAddMode -> showError("Amount must be greater than 0")
                 data.transferType == 0L && state.isAddMode -> showError("Transfer Type is Required")
 
                 data.instructionType == 0L && state.isAddMode -> showError("Instruction Type is Required")


### PR DESCRIPTION
The amount validation in `AddEditSIViewModel` used `any { !it.isDigit() }` to catch invalid input, but `isDigit()` returns false for `.`, so any decimal amount like `10.50` was rejected with "Amount is Invalid" even though the amount field uses `KeyboardType.Number` which allows decimal separators.

Replaced the character-level digit check with `toDoubleOrNull() == null` for format validation, and added a `<= 0` guard to reject zero and negative amounts. The null-path message is corrected to "Amount is Invalid" rather than the previous "Amount is Required".

Tested manually by entering `10.50`, `0`, `-5`, and `abc` in the standing instruction form to confirm each case is handled correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved amount field validation in Standing Instructions to provide clearer error messages and prevent invalid amounts (zero or negative values).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/mifos-pay/pull/2028)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->