### PR TITLE
fix(viewmodels): replace unsafe non-null assertions with safe null handling

### DIFF
--- a/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifospay/feature/home/HomeViewModel.kt
@@ -83,8 +83,11 @@ class HomeViewModel(
 
                                 // Save account external IDs map
                                 val accountExternalIds = result.data
-                                    .filter { !it.externalId.isNullOrBlank() }
-                                    .associate { it.id to it.externalId!! }
+                                    .mapNotNull { account ->
+                                        account.externalId?.takeIf { it.isNotBlank() }
+                                            ?.let { account.id to it }
+                                    }
+                                    .toMap()
                                 preferencesRepository.updateAccountExternalIds(accountExternalIds)
 
                                 if (selected != null) {
@@ -285,8 +288,8 @@ class HomeViewModel(
                         showBottomSheet = false,
                     )
                 }
-                if (state.currentSelectedAccount != null) {
-                    getAccountBasedOnId(state.currentSelectedAccount!!)
+                state.currentSelectedAccount?.let { account ->
+                    getAccountBasedOnId(account)
                 }
             }
 

--- a/feature/profile/src/commonMain/kotlin/org/mifospay/feature/profile/edit/EditProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/org/mifospay/feature/profile/edit/EditProfileViewModel.kt
@@ -236,10 +236,11 @@ internal class EditProfileViewModel(
 
             is DataState.Success -> {
                 viewModelScope.launch {
-                    if (state.profileImage != null) {
+                    val image = state.profileImage
+                    if (image != null) {
                         val result = clientRepository.updateClientImage(
                             state.clientId,
-                            state.profileImage!!.decodeToString(),
+                            image.decodeToString(),
                         )
                         sendAction(HandleUpdateClientImageResult(result))
                     }

--- a/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/createOrUpdate/AddEditCardViewModel.kt
+++ b/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/createOrUpdate/AddEditCardViewModel.kt
@@ -60,8 +60,9 @@ internal class AddEditCardViewModel(
             .onEach { savedStateHandle.setSerialized(key = ADD_EDIT_CARD_STATE_KEY, value = it) }
             .launchIn(viewModelScope)
 
-        if (state.type is CardAddEditType.EditItem) {
-            repository.getSavedCard(state.clientId, state.type.savedCardId!!).onEach {
+        val editType = state.type as? CardAddEditType.EditItem
+        if (editType != null) {
+            repository.getSavedCard(state.clientId, editType.savedCardId).onEach {
                 sendAction(HandleCardResult(it))
             }.launchIn(viewModelScope)
         }
@@ -181,7 +182,7 @@ internal class AddEditCardViewModel(
         }
 
         viewModelScope.launch {
-            when (state.type) {
+            when (val type = state.type) {
                 is CardAddEditType.AddItem -> {
                     val result = repository.addSavedCard(state.clientId, state.cardPayload)
 
@@ -191,7 +192,7 @@ internal class AddEditCardViewModel(
                 is CardAddEditType.EditItem -> {
                     val result = repository.updateCard(
                         clientId = state.clientId,
-                        cardId = state.type.savedCardId!!,
+                        cardId = type.savedCardId,
                         card = state.cardPayload,
                     )
 


### PR DESCRIPTION
Three ViewModels across the app use `!!` to dereference nullable state after a null check, but because `state` is read from a `StateFlow` via a property getter, the value can change between the check and the dereference. This pattern leads to `NullPointerException` crashes that are hard to reproduce consistently.

**HomeViewModel** — `externalId!!` inside a `.filter { !it.externalId.isNullOrBlank() }` chain is technically safe but fragile; replaced with `mapNotNull` which makes the intent explicit. The `currentSelectedAccount!!` after an `if (state.currentSelectedAccount != null)` guard is a textbook case of the stale-read problem; replaced with `?.let`.

**EditProfileViewModel** — `state.profileImage!!` inside a `if (state.profileImage != null)` block reads `state` twice through the getter. Capturing it to a local `val` before the check means both uses refer to the same snapshot.

**AddEditCardViewModel** — `state.type.savedCardId!!` is used in two places when the type is `EditItem`. In `init`, replaced the `is` check with `as?` so the cast and the null check are one operation. In `initiateAddOrEditCard`, captured `state.type` as a `val` in the `when` expression so Kotlin's smart cast kicks in and the `savedCardId` property is already non-nullable.

No behavior changes — these are correctness fixes to patterns that can crash under concurrent state updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code safety and reliability in home, profile, and saved cards features through enhanced null-handling patterns and more robust state management logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/mifos-pay/pull/2031)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->