### PR TITLE
fix(transfer-intrabank): correct floating-point truncation in amount display

### DIFF
--- a/feature/transfer-intrabank/src/commonMain/kotlin/org/mifospay/feature/transfer/intrabank/hub/components/RecentPayeeCard.kt
+++ b/feature/transfer-intrabank/src/commonMain/kotlin/org/mifospay/feature/transfer/intrabank/hub/components/RecentPayeeCard.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import kotlin.math.roundToInt
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -35,6 +34,7 @@ import org.mifospay.core.designsystem.component.MifosTextUserImage
 import org.mifospay.core.model.account.RecentPayee
 import template.core.base.designsystem.KptMaterialTheme
 import template.core.base.designsystem.theme.KptTheme
+import kotlin.math.roundToInt
 
 @Composable
 fun RecentPayeeCard(

--- a/feature/transfer-intrabank/src/commonMain/kotlin/org/mifospay/feature/transfer/intrabank/hub/components/RecentPayeeCard.kt
+++ b/feature/transfer-intrabank/src/commonMain/kotlin/org/mifospay/feature/transfer/intrabank/hub/components/RecentPayeeCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import kotlin.math.roundToInt
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -125,8 +126,9 @@ private fun formatAccountDisplay(accountNo: String): String {
  * Formats amount with currency symbol
  */
 private fun formatAmount(currency: String, amount: Double): String {
-    val wholePart = amount.toLong()
-    val decimalPart = ((amount - wholePart) * 100).toInt()
+    val cents = (amount * 100).roundToInt()
+    val wholePart = cents / 100
+    val decimalPart = cents % 100
     val formattedWhole = wholePart.toString()
         .reversed()
         .chunked(3)


### PR DESCRIPTION
The recent payee card shows the last amount you sent to a beneficiary — and for a lot of common amounts, it was showing the wrong value. ₹5.99 appears as ₹5.98. ₹99.99 appears as ₹99.98. ₹10.30 appears as ₹10.29. In a payments app, seeing a different amount than what you actually sent is genuinely alarming.

The root cause is a classic floating-point pitfall. The old code computed the decimal part like this:

```kotlin
val wholePart = amount.toLong()
val decimalPart = ((amount - wholePart) * 100).toInt()
```

The problem: `5.99 - 5` in floating-point is not `0.99` — it's `0.9899999999999999`. Multiply that by 100 and you get `98.99...`. Calling `.toInt()` truncates toward zero, so you get `98` instead of `99`. The display shows `5.98`.

This affects any amount where the decimal part has a negative epsilon in its binary representation, which includes most `.x9` endings and many others. It's unpredictable from the user's perspective, which makes it feel like data corruption.

The fix avoids floating-point subtraction entirely. Instead of splitting the number and computing the decimal part through subtraction, we multiply the whole amount by 100, round to the nearest integer, and then use integer division and modulo:

```kotlin
val cents = (amount * 100).roundToInt()
val wholePart = cents / 100
val decimalPart = cents % 100
```

Multiplying first keeps the rounding error small enough that `roundToInt()` always lands on the correct cent value.

| Amount | Before | After |
|--------|--------|-------|
| 5.99 | 5.98 | 5.99 |
| 99.99 | 99.98 | 99.99 |
| 10.30 | 10.29 | 10.30 |
| 63,823.00 | 63,823.00 | 63,823.00 |

Verified by tracing through the arithmetic manually for the failing cases and confirming the fixed output matches the expected display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how transfer amounts are rounded and displayed in the recent payee card.
  * Amounts now show more consistent two-decimal formatting, reducing edge cases where values could appear slightly off due to rounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->