### PR TITLE
fix(savedcards): refresh card list after delete and wire pull-to-refresh

### DIFF
--- a/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/CardsScreen.kt
+++ b/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/CardsScreen.kt
@@ -56,6 +56,7 @@ import org.mifospay.core.designsystem.component.LoadingDialogState
 import org.mifospay.core.designsystem.component.MifosBasicDialog
 import org.mifospay.core.designsystem.component.MifosLoadingDialog
 import org.mifospay.core.designsystem.component.MifosScaffold
+import org.mifospay.core.designsystem.component.rememberMifosPullToRefreshState
 import org.mifospay.core.designsystem.icon.MifosIcons
 import org.mifospay.core.model.savedcards.SavedCard
 import org.mifospay.core.ui.EmptyContentScreen
@@ -66,11 +67,6 @@ import org.mifospay.feature.savedcards.utils.CreditCardUtils.detectCardType
 import org.mifospay.feature.savedcards.utils.CreditCardUtils.maskCreditCardNumber
 import template.core.base.designsystem.theme.KptTheme
 
-/**
- * Known Issue, On deleting card, state isn't updating automatically
- * whereas on adding or updating, card state is updating properly,
- * This issue will be fixed soon.
- */
 @Composable
 fun CardsScreen(
     modifier: Modifier = Modifier,
@@ -156,6 +152,11 @@ internal fun CardsScreen(
         snackbarHostState = snackbarHostState,
         floatingActionButtonPosition = FabPosition.EndOverlay,
         modifier = modifier,
+        pullToRefreshState = rememberMifosPullToRefreshState(
+            isEnabled = state.isPullRefreshEnabled,
+            isRefreshing = false,
+            onRefresh = { onAction(CardAction.RefreshCards) },
+        ),
         floatingActionButton = {
             AnimatedVisibility(
                 visible = state.hasFab,

--- a/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/CardsScreenViewModel.kt
+++ b/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/CardsScreenViewModel.kt
@@ -13,7 +13,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
@@ -53,8 +55,13 @@ class CardsScreenViewModel(
         private const val KEY_STATE = "saved_card_state"
     }
 
+    private val refreshTrigger = MutableSharedFlow<Unit>(replay = 1).apply {
+        tryEmit(Unit)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
-    val cardState = repository.getSavedCards(state.clientId)
+    val cardState = refreshTrigger
+        .flatMapLatest { repository.getSavedCards(state.clientId) }
         .mapLatest { result ->
             when (result) {
                 is DataState.Loading -> ViewState.Loading
@@ -95,6 +102,8 @@ class CardsScreenViewModel(
                     it.copy(dialogState = null)
                 }
             }
+
+            is CardAction.RefreshCards -> refreshTrigger.tryEmit(Unit)
 
             is CardAction.DeleteCardClicked -> {
                 mutableStateFlow.update {
@@ -147,7 +156,7 @@ class CardsScreenViewModel(
                 mutableStateFlow.update {
                     it.copy(dialogState = null)
                 }
-
+                refreshTrigger.tryEmit(Unit)
                 sendEvent(CardEvent.ShowToast(action.result.data))
             }
         }
@@ -218,6 +227,7 @@ sealed interface CardAction {
     data class DeleteCardClicked(val cardId: Long) : CardAction
     data object DismissDialog : CardAction
     data object AddNewCard : CardAction
+    data object RefreshCards : CardAction
 
     sealed interface Internal : CardAction {
         data class DeleteCard(val cardId: Long) : Internal

--- a/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/CardsScreenViewModel.kt
+++ b/feature/savedcards/src/commonMain/kotlin/org/mifospay/feature/savedcards/CardsScreenViewModel.kt
@@ -103,7 +103,7 @@ class CardsScreenViewModel(
                 }
             }
 
-            is CardAction.RefreshCards -> refreshTrigger.tryEmit(Unit)
+            is CardAction.RefreshCards -> requestRefresh()
 
             is CardAction.DeleteCardClicked -> {
                 mutableStateFlow.update {
@@ -156,9 +156,15 @@ class CardsScreenViewModel(
                 mutableStateFlow.update {
                     it.copy(dialogState = null)
                 }
-                refreshTrigger.tryEmit(Unit)
+                requestRefresh()
                 sendEvent(CardEvent.ShowToast(action.result.data))
             }
+        }
+    }
+
+    private fun requestRefresh() {
+        viewModelScope.launch {
+            refreshTrigger.emit(Unit)
         }
     }
 }


### PR DESCRIPTION
Deleting a saved card left the list showing the deleted entry until you navigated away and back. The root cause was that `cardState` was built directly from a one-shot API flow: once it emitted and completed, there was nothing to trigger a re-fetch after a delete.

The fix introduces a `MutableSharedFlow<Unit>` as a refresh trigger (seeded with an initial emission so the first load still happens automatically). The `cardState` flow now uses `flatMapLatest` on that trigger, so every `tryEmit(Unit)` restarts the underlying `getSavedCards` call and the list updates immediately.

Two places now emit to the trigger:
- After a successful delete, so the removed card disappears right away
- When `CardAction.RefreshCards` is dispatched, which the screen sends on pull-to-refresh

The `isPullRefreshEnabled` property was already defined on `ViewState` but the scaffold was never wired up to it. This PR connects it via `rememberMifosPullToRefreshState`, so users can also manually refresh the list by pulling down.

The known-issue comment on `CardsScreen` is removed since the underlying problem is resolved.

Tested manually: deleting a card now removes it from the list without any navigation, and pull-to-refresh re-fetches correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull-to-refresh support added to saved cards screen—swipe down to manually refresh your card list.
  * Saved cards automatically refresh after successful deletion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/mifos-pay/pull/2037)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->