### PR TITLE
fix(history): re-enable transaction detail tap after self-service API migration

### DIFF
--- a/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/components/TransactionList.kt
+++ b/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/components/TransactionList.kt
@@ -93,14 +93,12 @@ internal fun TransactionItem(
     showDescription: Boolean = false,
     onClick: (Long) -> Unit,
 ) {
-//    TODO Disabling this view specific transfer details because of not using self api
     Surface(
         modifier = modifier,
         enabled = transaction.transferId != null,
-//        onClick = {
-//            transaction.transferId?.let { onClick(it) }
-//        },
-        onClick = { },
+        onClick = {
+            transaction.transferId?.let { onClick(it) }
+        },
         color = Color.Transparent,
         contentColor = KptTheme.colorScheme.onSurface,
     ) {


### PR DESCRIPTION
Tapping a transaction in the history list has never done anything. The `onClick` in `TransactionItem` was intentionally disabled with a comment saying transfer details couldn't be viewed because the endpoint wasn't using the self-service API.

That blocker no longer exists. `AccountRepositoryImpl.getAccountTransfer` was quietly migrated to `selfManager.accountTransfersApi` — the same self-service client used everywhere else in the app. The navigation, ViewModel, and event wiring were all fully implemented and waiting. The only thing left was uncommenting the click handler.

With this change, tapping any transaction that has a `transferId` navigates to the full transfer detail screen showing sender, recipient, amount, date, and transfer ID. Transactions without a `transferId` stay non-interactive, which is the correct behavior already expressed through the `enabled = transaction.transferId != null` check.

This also fixes `SpecificTransactionsScreen`, which passes an `onClick` to `TransactionItem` that was silently ignored for the same reason.

Tested by tracing the full call chain: `TransactionItem.onClick` → `HistoryAction.ViewTransaction` → `HistoryEvent.OnTransactionDetail` → `navigateToTransactionDetail(transferId)` → `TransactionDetailViewModel` fetching via self-service API → `TransactionDetail` composable rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction items are now properly clickable, enabling users to interact with transfer-related transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/mifos-pay/pull/2038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->