### PR TITLE
fix: transaction history details

### DIFF
--- a/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/MifosNavHost.kt
+++ b/cmp-shared/src/commonMain/kotlin/org/mifospay/shared/navigation/MifosNavHost.kt
@@ -208,7 +208,7 @@ internal fun MifosNavHost(
         },
         TabContent(stringResource(Res.string.feature_payments_history)) {
             HistoryScreen(
-                viewTransferDetail = navController::navigateToTransactionDetail,
+                viewTransferDetail = navController::navigateToSpecificTransaction,
             )
         },
 //        TabContent(PaymentsScreenContents.SI.name) {
@@ -375,7 +375,7 @@ internal fun MifosNavHost(
         )
 
         historyNavigation(
-            viewTransactionDetail = navController::navigateToTransactionDetail,
+            viewTransactionDetail = navController::navigateToSpecificTransaction,
         )
 
         paymentsScreen(tabContents = paymentsTabContents)

--- a/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryScreen.kt
+++ b/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryScreen.kt
@@ -65,7 +65,9 @@ fun HistoryScreen(
     EventsEffect(viewModel) { event ->
         when (event) {
             is HistoryEvent.OnTransactionDetail -> {
-                viewTransferDetail.invoke(state.selectedAccount?.id ?: -1L, event.transferId)
+                state.selectedAccount?.id?.let { accountId ->
+                    viewTransferDetail.invoke(accountId, event.transferId)
+                }
             }
         }
     }

--- a/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryScreen.kt
+++ b/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryScreen.kt
@@ -56,7 +56,7 @@ import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun HistoryScreen(
-    viewTransferDetail: (Long) -> Unit,
+    viewTransferDetail: (Long, Long) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: HistoryViewModel = koinViewModel(),
 ) {
@@ -65,7 +65,7 @@ fun HistoryScreen(
     EventsEffect(viewModel) { event ->
         when (event) {
             is HistoryEvent.OnTransactionDetail -> {
-                viewTransferDetail.invoke(event.transferId)
+                viewTransferDetail.invoke(state.selectedAccount?.id ?: -1L, event.transferId)
             }
         }
     }

--- a/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/HistoryViewModel.kt
@@ -59,6 +59,7 @@ class HistoryViewModel(
 
     private fun loadTransactions(accountId: Long) {
         repository.getTransactions(accountId, null).onEach { result ->
+
             when (result) {
                 is DataState.Error -> {
                     mutableStateFlow.update {

--- a/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/components/TransactionList.kt
+++ b/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/components/TransactionList.kt
@@ -93,14 +93,11 @@ internal fun TransactionItem(
     showDescription: Boolean = false,
     onClick: (Long) -> Unit,
 ) {
-//    TODO Disabling this view specific transfer details because of not using self api
     Surface(
         modifier = modifier,
-        enabled = transaction.transferId != null,
-//        onClick = {
-//            transaction.transferId?.let { onClick(it) }
-//        },
-        onClick = { },
+        onClick = {
+            onClick(transaction.transactionId)
+        },
         color = Color.Transparent,
         contentColor = KptTheme.colorScheme.onSurface,
     ) {

--- a/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/navigation/HistoryNavigation.kt
+++ b/feature/history/src/commonMain/kotlin/org/mifospay/feature/history/navigation/HistoryNavigation.kt
@@ -18,7 +18,7 @@ import org.mifospay.feature.history.HistoryScreen
 const val HISTORY_ROUTE = "history_route"
 
 fun NavGraphBuilder.historyNavigation(
-    viewTransactionDetail: (Long) -> Unit,
+    viewTransactionDetail: (Long, Long) -> Unit,
 ) {
     composable(HISTORY_ROUTE) {
         HistoryScreen(


### PR DESCRIPTION
https://mifosforge.jira.com/browse/MW-415

Before:

https://github.com/user-attachments/assets/48a7e6b5-4a57-4b17-a84a-87be98d723c0

After fix: 

https://github.com/user-attachments/assets/4962c7fd-2319-4714-a5f2-80dbefa2ef92


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction detail navigation now includes the account context so tapping a history item reliably opens the correct transaction.
  * Tapping a transaction item consistently triggers navigation to its detail view, improving selection reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->